### PR TITLE
Input deal with int64 values.

### DIFF
--- a/src/input/json_to_storage.cc
+++ b/src/input/json_to_storage.cc
@@ -5,6 +5,8 @@
  *      Author: jb
  */
 
+#include <boost/cstdint.hpp>
+#include <limits>
 #include <boost/iostreams/device/file.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
@@ -530,9 +532,12 @@ StorageBase * JSONToStorage::make_storage(JSONPath &p, const Type::Bool *bool_ty
 StorageBase * JSONToStorage::make_storage(JSONPath &p, const Type::Integer *int_type)
 {
     if (p.head()->type() == json_spirit::int_type) {
-        int value = p.head()->get_int();
-        int_type->match(value);
-        if (int_type->match(value)) {
+        boost::int64_t value = p.head()->get_int64();
+
+        if ( value >= std::numeric_limits<int>::min() &&
+             value <= std::numeric_limits<int>::max() &&
+             int_type->match(value) )
+        {
             return new StorageInt( value );
         } else {
             THROW( ExcInputError() << EI_Specification("Value out of bounds.") << EI_ErrorAddress(p) << EI_InputType(int_type->desc()) );
@@ -552,10 +557,10 @@ StorageBase * JSONToStorage::make_storage(JSONPath &p, const Type::Double *doubl
 {
     double value;
 
-    if (p.head()->type() == json_spirit::real_type) {
+    auto value_type = p.head()->type();
+    if (    value_type== json_spirit::real_type
+         || value_type == json_spirit::int_type) {
         value = p.head()->get_real();
-    } else if (p.head()->type() == json_spirit::int_type) {
-        value = p.head()->get_int();
     } else {
         THROW( ExcInputError() << EI_Specification("The value should be 'JSON real', but we found: ")
                 << EI_ErrorAddress(p) << EI_JSON_Type( json_type_names[ p.head()->type() ] ) << EI_InputType(double_type->desc()) );

--- a/unit_tests/input/json_to_storage_test.cpp
+++ b/unit_tests/input/json_to_storage_test.cpp
@@ -99,6 +99,7 @@ protected:
 TEST_F(InputJSONToStorageTest, Integer) {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     Type::Integer int_type(1,10);
+    Type::Integer any_int;
 
     {
         stringstream ss("5");
@@ -106,7 +107,10 @@ TEST_F(InputJSONToStorageTest, Integer) {
 
         EXPECT_EQ(5, storage_->get_int());
     }
-
+    {
+        stringstream ss("5000000000");
+        EXPECT_THROW_WHAT( {read_stream(ss, any_int);} , ExcInputError, "Value out of bounds.");
+    }
     {
         stringstream ss("0");
         EXPECT_THROW_WHAT( {read_stream(ss, int_type);} , ExcInputError, "Value out of bounds.");
@@ -120,12 +124,20 @@ TEST_F(InputJSONToStorageTest, Integer) {
 TEST_F(InputJSONToStorageTest, Double) {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     Type::Double dbl_type(1.1,10.1);
+    Type::Double any_double;
 
     {
         stringstream ss("5.5");
         read_stream(ss, dbl_type);
 
         EXPECT_EQ(5.5, storage_->get_double());
+    }
+
+    {
+        stringstream ss("5000000000000");
+        read_stream(ss, any_double);
+
+        EXPECT_EQ(5e12, storage_->get_double());
     }
 
     {


### PR DESCRIPTION
- real input types can be initialized by long integer values.
- long int values are reported as errors