### PR TITLE
JHy profiler fix

### DIFF
--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -425,7 +425,6 @@ void Profiler::update_running_timers() {
 
 #ifdef FLOW123D_HAVE_MPI
 void Profiler::output(MPI_Comm comm, ostream &os) {
-    // only active communicator should be the one with mpi_rank 0
     int ierr, mpi_rank, mpi_size;
     ierr = MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
     ASSERT(ierr == 0, "Error in MPI test of rank.");
@@ -464,13 +463,19 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     root.add_child ("children", children);
 
 
-    /**
-     * Flag to property_tree::write_json method
-     * resulting in json human readable format (indents, newlines)
-     */
-    const int FLOW123D_JSON_HUMAN_READABLE = 1;
-    // write result to stream
-    property_tree::write_json (os, root, FLOW123D_JSON_HUMAN_READABLE);
+    // create profiler output only once (on the first processor)
+    // only active communicator should be the one with mpi_rank 0
+    if (mpi_rank == 0) {
+        cout << "MPI_Comm_size writing: " << mpi_size << endl;
+        cout << "MPI_Comm_rank writing: " << mpi_rank << endl;
+        /**
+         * Flag to property_tree::write_json method
+         * resulting in json human readable format (indents, newlines)
+         */
+        const int FLOW123D_JSON_HUMAN_READABLE = 1;
+        // write result to stream
+        property_tree::write_json (os, root, FLOW123D_JSON_HUMAN_READABLE);
+    }
 }
 
 
@@ -483,20 +488,14 @@ void Profiler::output(MPI_Comm comm) {
     ASSERT(ierr == 0, "Error in MPI test of rank.");
     MPI_Comm_size(comm, &mpi_size);
 
-    cout << "MPI_Comm_size: " << mpi_size << endl;
-    cout << "MPI_Comm_rank: " << mpi_rank << endl;
-    // create profiler output only once (on the first processor)
+    char filename[PATH_MAX];
+    strftime(filename, sizeof (filename) - 1, "profiler_info_%y.%m.%d_%H-%M-%S.log.json", localtime(&start_time));
+    string full_fname =  FilePath(string(filename), FilePath::output_file);
 
-    if (mpi_rank == 0) {
-        char filename[PATH_MAX];
-        strftime(filename, sizeof (filename) - 1, "profiler_info_%y.%m.%d_%H-%M-%S.log.json", localtime(&start_time));
-        string full_fname =  FilePath(string(filename), FilePath::output_file);
-
-        xprintf(MsgLog, "output into: %s\n", full_fname.c_str());
-        ofstream os(full_fname.c_str());
-        output(comm, os);
-        os.close();
-    }
+    xprintf(MsgLog, "output into: %s\n", full_fname.c_str());
+    ofstream os(full_fname.c_str());
+    output(comm, os);
+    os.close();
 }
 
 #endif /* FLOW123D_HAVE_MPI */

--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -433,43 +433,47 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     ASSERT(ierr == 0, "Error in MPI test of rank.");
     MPI_Comm_size(comm, &mpi_size);
 
-    // output header
-    property_tree::ptree root, children;
-    output_header (root, mpi_size);
+    // create profiler output only once (on the first processor)
+    if (mpi_rank == 0) {
 
-    // recursively add all timers info
-    // define lambda function which reduces timer from multiple processors
-    // MPI implementation uses MPI call to reduce values
-    auto reduce = [=] (Timer &timer, property_tree::ptree &node) -> double {
-        int call_count = timer.call_count;
-        double cumul_time = timer.cumulative_time () / 1000;
-        double cumul_time_sum;
+        // output header
+        property_tree::ptree root, children;
+        output_header (root, mpi_size);
 
-        node.put ("call-count", call_count);
-        node.put ("call-count-min", MPI_Functions::min(&call_count, comm));
-        node.put ("call-count-max", MPI_Functions::max(&call_count, comm));
-        node.put ("call-count-sum", MPI_Functions::sum(&call_count, comm));
+        // recursively add all timers info
+        // define lambda function which reduces timer from multiple processors
+        // MPI implementation uses MPI call to reduce values
+        auto reduce = [=] (Timer &timer, property_tree::ptree &node) -> double {
+            int call_count = timer.call_count;
+            double cumul_time = timer.cumulative_time () / 1000;
+            double cumul_time_sum;
 
-        cumul_time_sum = MPI_Functions::sum(&cumul_time, comm);
+            node.put ("call-count", call_count);
+            node.put ("call-count-min", MPI_Functions::min(&call_count, comm));
+            node.put ("call-count-max", MPI_Functions::max(&call_count, comm));
+            node.put ("call-count-sum", MPI_Functions::sum(&call_count, comm));
 
-        node.put ("cumul-time", boost::format("%1.9f") % cumul_time);
-        node.put ("cumul-time-min", boost::format("%1.9f") % MPI_Functions::min(&cumul_time, comm));
-        node.put ("cumul-time-max", boost::format("%1.9f") % MPI_Functions::max(&cumul_time, comm));
-        node.put ("cumul-time-sum", boost::format("%1.9f") % cumul_time_sum);
-        return cumul_time_sum;
-    };
+            cumul_time_sum = MPI_Functions::sum(&cumul_time, comm);
 
-    add_timer_info (reduce, &children, 0, 0.0);
-    root.add_child ("children", children);
+            node.put ("cumul-time", boost::format("%1.9f") % cumul_time);
+            node.put ("cumul-time-min", boost::format("%1.9f") % MPI_Functions::min(&cumul_time, comm));
+            node.put ("cumul-time-max", boost::format("%1.9f") % MPI_Functions::max(&cumul_time, comm));
+            node.put ("cumul-time-sum", boost::format("%1.9f") % cumul_time_sum);
+            return cumul_time_sum;
+        };
+
+        add_timer_info (reduce, &children, 0, 0.0);
+        root.add_child ("children", children);
 
 
-    /**
-     * Flag to property_tree::write_json method
-     * resulting in json human readable format (indents, newlines)
-     */
-    const int FLOW123D_JSON_HUMAN_READABLE = 1;
-    // write result to stream
-    property_tree::write_json (os, root, FLOW123D_JSON_HUMAN_READABLE);
+        /**
+         * Flag to property_tree::write_json method
+         * resulting in json human readable format (indents, newlines)
+         */
+        const int FLOW123D_JSON_HUMAN_READABLE = 1;
+        // write result to stream
+        property_tree::write_json (os, root, FLOW123D_JSON_HUMAN_READABLE);
+    }
 }
 
 

--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -433,8 +433,8 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     ASSERT(ierr == 0, "Error in MPI test of rank.");
     MPI_Comm_size(comm, &mpi_size);
 
-    cout << "MPI_Comm_size" << mpi_size << endl;
-    cout << "MPI_Comm_rank" << mpi_rank << endl;
+    cout << "MPI_Comm_size: " << mpi_size << endl;
+    cout << "MPI_Comm_rank: " << mpi_rank << endl;
     // create profiler output only once (on the first processor)
     if (mpi_rank == 0) {
 

--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -433,6 +433,8 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     ASSERT(ierr == 0, "Error in MPI test of rank.");
     MPI_Comm_size(comm, &mpi_size);
 
+    cout << "MPI_Comm_size" << mpi_size << endl;
+    cout << "MPI_Comm_rank" << mpi_rank << endl;
     // create profiler output only once (on the first processor)
     if (mpi_rank == 0) {
 
@@ -473,6 +475,8 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
         const int FLOW123D_JSON_HUMAN_READABLE = 1;
         // write result to stream
         property_tree::write_json (os, root, FLOW123D_JSON_HUMAN_READABLE);
+    } else {
+        // other MPI processes won't be doing anything
     }
 }
 
@@ -610,5 +614,3 @@ void Profiler::uninitialize() {
 
 
 #endif // def FLOW123D_DEBUG_PROFILER
-
-

--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -430,9 +430,6 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     ASSERT(ierr == 0, "Error in MPI test of rank.");
     MPI_Comm_size(comm, &mpi_size);
 
-    cout << "opened stream MPI_Comm_size: " << mpi_size << endl;
-    cout << "opened stream MPI_Comm_rank: " << mpi_rank << endl;
-
     // output header
     property_tree::ptree root, children;
     output_header (root, mpi_size);
@@ -466,8 +463,6 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     // create profiler output only once (on the first processor)
     // only active communicator should be the one with mpi_rank 0
     if (mpi_rank == 0) {
-        cout << "MPI_Comm_size writing: " << mpi_size << endl;
-        cout << "MPI_Comm_rank writing: " << mpi_rank << endl;
         /**
          * Flag to property_tree::write_json method
          * resulting in json human readable format (indents, newlines)

--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -436,7 +436,7 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
     cout << "MPI_Comm_size: " << mpi_size << endl;
     cout << "MPI_Comm_rank: " << mpi_rank << endl;
     // create profiler output only once (on the first processor)
-    if (mpi_rank == 0) {
+    //if (mpi_rank == 0) {
 
         // output header
         property_tree::ptree root, children;
@@ -475,9 +475,9 @@ void Profiler::output(MPI_Comm comm, ostream &os) {
         const int FLOW123D_JSON_HUMAN_READABLE = 1;
         // write result to stream
         property_tree::write_json (os, root, FLOW123D_JSON_HUMAN_READABLE);
-    } else {
+    /*} else {
         // other MPI processes won't be doing anything
-    }
+    }*/
 }
 
 


### PR DESCRIPTION
Pull which fixes broken json profiler files #396 (not sure abour #393 need more testing).
Writing section was wrapped in condition that only **mpi rank 0** can access.

*Note:*
Profiler has methods:
```cc
void Profiler::output(MPI_Comm comm);
void Profiler::output(MPI_Comm comm, ostream &os);
```
When in paralell all processors possess ```ostream &os``` variable even though it is not used. Possible solution can be following:
```cc
property_tree::ptree Profiler::collect_data(MPI_Comm comm);
void Profiler::output();
void Profiler::output(ostream &os);
```
