### PR TITLE
Fix invalid JSON output

### DIFF
--- a/src/input/type_output.cc
+++ b/src/input/type_output.cc
@@ -770,7 +770,7 @@ void OutputJSONMachine::print_impl(ostream& stream, const Parameter *type) {
     stream << "{" << endl;
     stream << "\"id\" : \"" << format_hash(hash) << "\"," << endl;
     stream << "\"input_type\" : \"Parameter\"," << endl;
-    stream << "\"name\" : \"" << type->type_name() << "\"," << endl;
+    stream << "\"name\" : \"" << type->type_name() << "\"" << endl;
 	stream << "},";
 
 	boost::hash_combine(full_hash_, hash);

--- a/src/python/ist/ist_formatter_module.py
+++ b/src/python/ist/ist_formatter_module.py
@@ -13,8 +13,9 @@ from ist.utils.htmltree import htmltree
 class ProfilerJSONDecoder(json.JSONDecoder):
     def decode(self, json_string):
         default_obj = super(ProfilerJSONDecoder, self).decode(json_string)
+        ist_nodes = default_obj.get('ist_nodes')
         lst = TypedList()
-        lst.parse(default_obj)
+        lst.parse(ist_nodes)
         return lst
 
 

--- a/src/python/ist/utils/utils.py
+++ b/src/python/ist/utils/utils.py
@@ -72,7 +72,7 @@ class AttributeDict(dict):
         :return: self
         """
         for attribute in lst:
-            self[attribute['name']] = self.cls().parse(attribute) if self.cls else attribute
+            self[attribute] = lst[attribute]
 
         return self
 


### PR DESCRIPTION
Fix IST formaters for new shape of the IST file.
- Fix output of Parameter type. (invalid JSON)
- Fix Decoder to read type list from the key 'ist_nodes'.