### PR TITLE
JHy mpi fix

### DIFF
--- a/src/system/sys_profiler.cc
+++ b/src/system/sys_profiler.cc
@@ -183,7 +183,8 @@ void Profiler::initialize()
 Profiler::Profiler()
 : actual_node(0),
   task_size_(1),
-  start_time( time(NULL) )
+  start_time( time(NULL) ),
+  json_filepath("")
 
 {
 #ifdef FLOW123D_DEBUG_PROFILER

--- a/unit_tests/system/tokenizer_speed_test.cpp
+++ b/unit_tests/system/tokenizer_speed_test.cpp
@@ -5,9 +5,7 @@
  *      Author: jb
  */
 
-#define TEST_USE_MPI
-
-#include <flow_gtest_mpi.hh>
+#include <flow_gtest.hh>
 
 #include "system/global_defs.h"
 
@@ -49,7 +47,7 @@ TEST(TokenizerPosition, compare_speed) {
 	EXPECT_EQ(position_data.size(), file_line_count);
 
 	Profiler::initialize();
-	FilePath in_file("/system/tokenizer_speed.txt", FilePath::input_file);
+	FilePath in_file("./system/tokenizer_speed.txt", FilePath::input_file);
 
 	// read data by tokenizer
 	{
@@ -94,7 +92,7 @@ TEST(TokenizerPosition, compare_speed) {
 		binary_file.close();
 	}
 
-	Profiler::instance()->output(MPI_COMM_WORLD, cout);
+	Profiler::instance()->output(cout);
 	Profiler::uninitialize();
 }
 


### PR DESCRIPTION
- fix unit tests for processor with rank 0 and others (now different tests)
- set empty json_filepath in constructor
- remove MPI dependency in test, [file absolute path to relative](https://github.com/flow123d/flow123d/blob/JHy_mpi_fix/unit_tests/system/tokenizer_speed_test.cpp#L50) don't know if that behavior was correct or not.

there was an error if file was (one simply cannot write to `/system/`):
```c++
FilePath in_file("/system/tokenizer_speed.txt", FilePath::input_file);
```
I made path relative (using dot) and test works now.
```c++
FilePath in_file("./system/tokenizer_speed.txt", FilePath::input_file);
```