### PR TITLE
Js fix mem leaks 183

### DIFF
--- a/src/system/application_base.cc
+++ b/src/system/application_base.cc
@@ -11,6 +11,14 @@
 #include "system/application_base.hh"
 #include "system/sys_profiler.hh"
 
+// Function that catches all program signals.
+PetscErrorCode signal_handler(int signal, void *context)
+{
+  THROW( ExcSignal() << EI_Signal(signal) << EI_SignalName(strsignal(signal)) );
+  
+  return 0;
+}
+
 
 ApplicationBase::ApplicationBase(int argc,  char ** argv)
 : log_filename_("")
@@ -75,6 +83,7 @@ PetscErrorCode ApplicationBase::petscvfprintf(FILE *fd, const char format[], va_
 }
 #endif
 
+
 void ApplicationBase::petsc_initialize(int argc, char ** argv) {
 #ifdef HAVE_PETSC
     if (petsc_redirect_file_ != "") {
@@ -84,6 +93,7 @@ void ApplicationBase::petsc_initialize(int argc, char ** argv) {
 
 
     PetscInitialize(&argc,&argv,PETSC_NULL,PETSC_NULL);
+    PetscPushSignalHandler(signal_handler, nullptr);
 
     int mpi_size;
     MPI_Comm_size(PETSC_COMM_WORLD, &mpi_size);

--- a/src/system/application_base.hh
+++ b/src/system/application_base.hh
@@ -21,6 +21,10 @@
 
 using namespace std;
 
+// Exception that prints the signal number and name.
+TYPEDEF_ERR_INFO( EI_Signal, int);
+TYPEDEF_ERR_INFO( EI_SignalName, string);
+DECLARE_EXCEPTION( ExcSignal, << "[ Signal " << EI_Signal::val << " (" << EI_SignalName::val << ") received! ]" );
 
 
 /**

--- a/src/transport/transport_dg.cc
+++ b/src/transport/transport_dg.cc
@@ -593,7 +593,7 @@ void TransportDG<Model>::update_solution()
     	{
     		ls[i]->finish_assembly();
 
-    		VecDuplicate(*( ls[i]->get_rhs() ), &rhs[i]);
+    		if (rhs[i] == nullptr) VecDuplicate(*( ls[i]->get_rhs() ), &rhs[i]);
     		VecCopy(*( ls[i]->get_rhs() ), rhs[i]);
     	}
     }

--- a/unit_tests/system/application_base_test.cpp
+++ b/unit_tests/system/application_base_test.cpp
@@ -12,6 +12,13 @@ protected:
 	void run() {
 		xprintf(Err, "testing error...\n");
 	}
+	
+	void seg_fault() {
+      // Attempt to read from unallocated memory.
+      petsc_initialize(0, nullptr);
+      int *i = nullptr;
+      printf("%d", i[0]);
+    }
 
     virtual void SetUp() {
     }
@@ -22,4 +29,5 @@ protected:
 
 TEST_F(ApplicationBaseTest, Exceptions) {
 	EXPECT_THROW_WHAT( {run();}, ExcXprintfMsg, "testing error...");
+    EXPECT_THROW_WHAT( {seg_fault();}, ExcSignal, "Signal 11" );
 }


### PR DESCRIPTION
Follows instructions from branch JS_fix_mem_leaks_182. Resolves #521.
Except for the first commit 0a984fa, it should be cherry-picked to master.