### PR TITLE
DF consistent mark times

### DIFF
--- a/src/fields/field_common.cc
+++ b/src/fields/field_common.cc
@@ -66,10 +66,11 @@ const std::string FieldCommon::field_descriptor_record_description(const string&
 
 
 
-void FieldCommon::mark_input_times(TimeMark::Type mark_type) {
+void FieldCommon::mark_input_times(const TimeGovernor &tg) {
     if (! flags().match(FieldFlag::declare_input)) return;
 
     // pass through field descriptors containing key matching field name.
+    TimeMark::Type mark_type = tg.equation_fixed_mark_type();
     double time;
     for( auto &item : shared_->input_list_) {
         time = item.val<double>("time"); // default time=0

--- a/src/fields/field_common.hh
+++ b/src/fields/field_common.hh
@@ -290,7 +290,7 @@ public:
      * Further development:
      * - we have to distinguish "jump" times and "smooth" times
      */
-    void mark_input_times(TimeMark::Type mark_type);
+    void mark_input_times(const TimeGovernor &tg);
 
     /**
      * Abstract method to update field to the new time level.

--- a/src/fields/field_set.hh
+++ b/src/fields/field_set.hh
@@ -207,8 +207,8 @@ public:
     /**
      * Collective interface to @p FieldCommonBase::mar_input_times().
      */
-    void mark_input_times(TimeMark::Type mark_type) {
-    	for(auto field : field_list) field->mark_input_times(mark_type);
+    void mark_input_times(const TimeGovernor &tg) {
+    	for(auto field : field_list) field->mark_input_times(tg);
     }
 
     /**

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -308,7 +308,7 @@ DarcyFlowMH_Steady::DarcyFlowMH_Steady(Mesh &mesh_in, const Input::Record in_rec
     if (make_tg) {
     	// steady time governor
     	time_ = new TimeGovernor();
-    	data_.mark_input_times(this->mark_type());
+    	data_.mark_input_times(this->time());
     	data_.set_time(time_->step(), LimitSide::right);
 
     	create_linear_system();
@@ -1553,7 +1553,7 @@ DarcyFlowMH_Unsteady::DarcyFlowMH_Unsteady(Mesh &mesh_in, const Input::Record in
     : DarcyFlowMH_Steady(mesh_in, in_rec, false)
 {
     time_ = new TimeGovernor(in_rec.val<Input::Record>("time"));
-	data_.mark_input_times(this->mark_type());
+	data_.mark_input_times(this->time());
 	data_.set_time(time_->step(), LimitSide::right);
 
 	output_object = new DarcyFlowMHOutput(this, in_rec.val<Input::Record>("output"));

--- a/src/flow/richards_lmh.cc
+++ b/src/flow/richards_lmh.cc
@@ -48,7 +48,7 @@ DarcyFlowLMH_Unsteady::DarcyFlowLMH_Unsteady(Mesh &mesh_in, const  Input::Record
     : DarcyFlowMH_Steady(mesh_in, in_rec,false)
 {
     time_ = new TimeGovernor(in_rec.val<Input::Record>("time"));
-    data_.mark_input_times(this->mark_type());
+    data_.mark_input_times(this->time());
 
     data_.set_time(time_->step(), LimitSide::right);
 

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -119,7 +119,6 @@ ConvectionTransport::ConvectionTransport(Mesh &init_mesh, const Input::Record in
 
 void ConvectionTransport::initialize()
 {
-	cout << "ConvectionTransport::initialize()";
     target_mark_type = time_->equation_fixed_mark_type();
 
     cfl_max_step = time_->end_time();
@@ -476,7 +475,6 @@ void ConvectionTransport::compute_concentration_sources() {
 
 void ConvectionTransport::zero_time_step()
 {
-	cout << "ConvectionTransport::zero_time_step()" << endl;
 	ASSERT_EQUAL(time_->tlevel(), 0);
 
 	data_.mark_input_times(*time_);

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -119,6 +119,7 @@ ConvectionTransport::ConvectionTransport(Mesh &init_mesh, const Input::Record in
 
 void ConvectionTransport::initialize()
 {
+	cout << "ConvectionTransport::initialize()";
     target_mark_type = time_->equation_fixed_mark_type();
 
     cfl_max_step = time_->end_time();
@@ -475,9 +476,10 @@ void ConvectionTransport::compute_concentration_sources() {
 
 void ConvectionTransport::zero_time_step()
 {
+	cout << "ConvectionTransport::zero_time_step()" << endl;
 	ASSERT_EQUAL(time_->tlevel(), 0);
 
-	data_.mark_input_times(target_mark_type);
+	data_.mark_input_times(*time_);
 	data_.set_time(time_->step(), LimitSide::right);
 
     set_initial_condition();

--- a/src/transport/transport_dg.cc
+++ b/src/transport/transport_dg.cc
@@ -415,7 +415,7 @@ template<class Model>
 void TransportDG<Model>::zero_time_step()
 {
 	START_TIMER(Model::ModelEqData::name());
-	data_.mark_input_times(Model::time_->equation_fixed_mark_type());
+	data_.mark_input_times( *(Model::time_) );
 	data_.set_time(Model::time_->step(), LimitSide::left);
 
 

--- a/unit_tests/fields/field_algo_base_test.cpp
+++ b/unit_tests/fields/field_algo_base_test.cpp
@@ -246,8 +246,8 @@ TYPED_TEST(FieldFix, mark_input_times) {
 	this->field_.set_input_list(this->input_list(list_ok));
 
 	TimeGovernor tg;
-	TimeMark::Type mark_type = tg.marks().new_mark_type();
-	this->field_.mark_input_times(mark_type);
+	TimeMark::Type mark_type = tg.marks().type_fixed_time();
+	this->field_.mark_input_times(tg);
 	auto it = tg.marks().next(tg, mark_type);
 	EXPECT_EQ( 1, it->time());
 	EXPECT_TRUE( it->match_mask(mark_type) );

--- a/unit_tests/fields/field_set_test.cpp
+++ b/unit_tests/fields/field_set_test.cpp
@@ -275,7 +275,7 @@ TEST_F(SomeEquation, input_related) {
     data.set_mesh(*mesh_);
     TimeGovernor tg(0.0, 0.5);
 
-    data.mark_input_times(tg.equation_mark_type());
+    data.mark_input_times(tg);
     Region front_3d = mesh_->region_db().find_id(40);
     // time = 0.0
     data.set_time(tg.step(), LimitSide::right);


### PR DESCRIPTION
- use TimeGovernor as method argument
- unification with mark_output_times method
- apply in DarcyFlow and Transport
- fix fields unit tests