### PR TITLE
JHy python formatter

### DIFF
--- a/src/python/ist/base.py
+++ b/src/python/ist/base.py
@@ -50,7 +50,7 @@ class InputType(object):
 
 
 class Field(object):
-    def __init__(self, names, t=str, index=False, subtype=None, save_as=None, required=False, link_to_parent=False):
+    def __init__(self, names, t=str, index=False, subtype=None, save_as=None, required=False, link_to_parent=False, default=None):
         """
         :type subtype: class
         """
@@ -61,6 +61,7 @@ class Field(object):
         self.subtype = subtype
         self.save_as = save_as or self.names[0]
         self.link_to_parent = link_to_parent
+        self.default = default
 
     def parse(self, json_data):
         for name in self.names:
@@ -73,6 +74,9 @@ class Field(object):
                     return instance.parse(json_data[name])
 
                 return json_data[name]
+
+        if self.default:
+            return self.default
 
         if self.required:
             raise

--- a/src/python/ist/base.py
+++ b/src/python/ist/base.py
@@ -245,6 +245,13 @@ class List(list):
         return len(self) == 1
 
 
+class SmartList(List):
+    def parse(self, json_data):
+        if type(json_data) is dict:
+            return super(SmartList, self).parse([dict([x]) for x in json_data.items()])
+        return super(SmartList, self).parse(json_data)
+
+
 class Dict(dict):
     def parse(self, json_data):
         for key, value in json_data.items():

--- a/src/python/ist/extras.py
+++ b/src/python/ist/extras.py
@@ -209,28 +209,21 @@ class TypeAttributes(Parsable):
     """
     :type obsolete       : unicode
     :type link_name      : unicode
-    :type parameters     : list[TypeAttributeParameter]
-    :type generic_type   : ist.extras.TypeReference
     :type input_type     : InputType
     """
     __fields__ = [
         Field('obsolete', t=str),
         Field('link_name', index=True),
-        Field('parameters', t=List, subtype=TypeAttributeParameter),
-        Field('generic_type', t=TypeReference),
     ]
 
     def __init__(self):
         super(TypeAttributes, self).__init__()
         self.obsolete = None
         self.link_name = None
-        self.parameters = None
-        self.generic_type = None
         self.input_type = InputType().parse('')
 
     def __repr__(self):
-        if self.obsolete is None and self.link_name is None \
-                and self.parameters is None and self.generic_type is None:
+        if self.obsolete is None and self.link_name is None:
             return '{}'
         return super(TypeAttributes, self).__repr__()
 
@@ -238,10 +231,12 @@ class TypeAttributes(Parsable):
         """
         :rtype : Dict
         """
-        if not self.parameters:
-            return Dict()
-
-        result = Dict()
-        for p in self.parameters:
-            result[p.name] = p
-        return result
+        # TODO compatibility
+        return Dict()
+        # if not self.parameters:
+        #     return Dict()
+        #
+        # result = Dict()
+        # for p in self.parameters:
+        #     result[p.name] = p
+        # return result

--- a/src/python/ist/formatters/html2latex.py
+++ b/src/python/ist/formatters/html2latex.py
@@ -128,7 +128,6 @@ class Html2Latex(object):
             self.extend_children()
             self.add_tail()
 
-
         # so far, code tag will be monospaced only
         elif self.tag_is('code'):
             # self.tex.open_element ('lstlisting')

--- a/src/python/ist/formatters/json2html.py
+++ b/src/python/ist/formatters/json2html.py
@@ -87,10 +87,10 @@ class HTMLSelection(HTMLItemFormatter):
                         self.item_list_title(selection_value, add_link=True)
                         self.description(selection_value.description)
 
-        if selection.attributes.parameters:
+        if selection.parameters:
             self.italic('Parameters', attrib={'class': 'section-list'})
             with self.open('ul', attrib={'class': 'item-list'}):
-                for param in selection.attributes.parameters:
+                for param in selection.parameters:
                     reference = param.reference.get_reference()
                     with self.open('li'):
                         with self.open('section', attrib={'class': 'record-param'}):
@@ -157,10 +157,10 @@ class HTMLRecord(HTMLItemFormatter):
                                 self.info(', ')
             self.main_section_title(record)
 
-            if record.attributes.generic_type:
+            if record.generic_type:
                 with self.open('div'):
                     self.italic('Generic type: ')
-                    self.link_to_main(record.attributes.generic_type.get_reference())
+                    self.link_to_main(record.generic_type.get_reference())
 
             if record.reducible_to_key:
                 with self.open('div'):
@@ -194,10 +194,10 @@ class HTMLRecord(HTMLItemFormatter):
                             # fmt.format(record_key, record)
                             # self.add(fmt.current())
 
-        if record.attributes.parameters:
+        if record.parameters:
             self.italic('Parameters', attrib={'class': 'section-list'})
             with self.open('ul', attrib={'class': 'item-list'}):
-                for param in record.attributes.parameters:
+                for param in record.parameters:
                     reference = param.reference.get_reference()
                     with self.open('li'):
                         with self.open('section', attrib={'class': 'record-param'}):
@@ -272,7 +272,7 @@ class HTMLRecord(HTMLItemFormatter):
                             self.span(str(subtype.input_type))
                         else:
                             # self.tag('br')
-                            if not subtype.attributes.generic_type:
+                            if not subtype.generic_type:
                                 self.info(' of ')
                                 with self.open('span', attrib={'class': 'item-value chevron'}):
                                     self.link_to_main(subtype)
@@ -281,7 +281,7 @@ class HTMLRecord(HTMLItemFormatter):
             if input_type == InputType.MAIN_TYPE:
                 with self.open('ul', cls='side-info'):
                     with self.open('li'):
-                        if not reference.attributes.generic_type:
+                        if not reference.generic_type:
                             with self.open('span', attrib={'class': 'item-key'}):
                                 self.span(str(reference.input_type))
                             with self.open('span', attrib={'class': 'item-value chevron'}):
@@ -295,16 +295,16 @@ class HTMLRecord(HTMLItemFormatter):
                         self.add_genericity(reference)
 
     def add_genericity(self, item):
-        if not item.attributes.generic_type:
+        if not item.generic_type:
             return
-        generic_class = item.attributes.generic_type.get_reference()
+        generic_class = item.generic_type.get_reference()
         generic_impl = item
         with self.open('li'):
             self.info(' generic type')
             with self.open('span', attrib={'class': 'item-value chevron'}):
                 self.link_to_main(generic_class)
 
-        for param in generic_impl.attributes.parameters:
+        for param in generic_impl.parameters:
             # self.tag('br')
             with self.open('li'):
                 self.info('parameter ')
@@ -379,10 +379,10 @@ class HTMLAbstractRecord(HTMLItemFormatter):
                     self.italic('Default descendant: ')
                     self.link_to_main(reference)
 
-            if abstract_record.attributes.generic_type:
+            if abstract_record.generic_type:
                 with self.open('div'):
                     self.italic('Generic type: ')
-                    self.link_to_main(abstract_record.attributes.generic_type.get_reference())
+                    self.link_to_main(abstract_record.generic_type.get_reference())
 
             self.italic('Description', attrib={'class': 'section-list'})
             self.description(abstract_record.description)
@@ -398,10 +398,10 @@ class HTMLAbstractRecord(HTMLItemFormatter):
                                 self.link_to_main(reference)
                             self.span(reference.description)
 
-        if abstract_record.attributes.parameters:
+        if abstract_record.parameters:
             self.italic('Parameters', attrib={'class': 'section-list'})
             with self.open('ul', attrib={'class': 'item-list'}):
-                for param in abstract_record.attributes.parameters:
+                for param in abstract_record.parameters:
                     reference = param.reference.get_reference()
                     with self.open('li'):
                         with self.open('section', attrib={'class': 'record-param'}):

--- a/src/python/ist/ist_formatter_module.py
+++ b/src/python/ist/ist_formatter_module.py
@@ -22,7 +22,6 @@ class ISTFormatter(object):
     Class for formatting json to other formats
     """
 
-
     @staticmethod
     def json2latex(items, output_file='../../docs/input_reference_red.tex', info=None):
         """

--- a/src/python/ist/nodes.py
+++ b/src/python/ist/nodes.py
@@ -3,8 +3,24 @@
 # author:   Jan Hybs
 
 from __future__ import absolute_import
-from ist.extras import TypeSelectionValue, TypeReference, TypeRecordKey, TypeRange, TypeAttributes
-from ist.base import Field, Parsable, InputType, List, Unicode
+from ist.extras import TypeSelectionValue, TypeReference, TypeRecordKey, TypeRange, TypeAttributes, \
+    TypeAttributeParameter
+from ist.base import Field, Parsable, InputType, List, Unicode, SmartList
+
+
+# used in all node types
+base_fields = [
+    Field("id", index=True),
+    Field("attributes", t=TypeAttributes, default=TypeAttributes()),
+    Field('parameters', t=SmartList, subtype=TypeAttributeParameter),
+    Field('generic_type', t=TypeReference),
+    Field("input_type", t=InputType),
+]
+
+# used in primitive node types (int, double, str, ...) where name is not part of index
+simple_fields = base_fields + [
+    Field(["name", "type_name"])
+]
 
 
 class TypeSelection(Parsable):
@@ -16,13 +32,12 @@ class TypeSelection(Parsable):
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
     :type description        : unicode
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
+    __fields__ = base_fields + [
         Field("values", t=List, subtype=TypeSelectionValue, link_to_parent=True, default=[]),
         Field(["name", "type_name"], index=True),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("description"),
     ]
 
@@ -34,6 +49,8 @@ class TypeSelection(Parsable):
         self.input_type = None
         self.attributes = None
         self.description = None
+        self.parameters = None
+        self.generic_type = None
 
     def include_in_format(self):
         return self.name.find('TYPE') == -1
@@ -56,14 +73,13 @@ class TypeRecord(Parsable):
     :type attributes         : ist.extras.TypeAttributes
     :type description        : unicode
     :type reducible_to_key   : Unicode
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
+    __fields__ = base_fields + [
         Field("keys", t=List, subtype=TypeRecordKey, link_to_parent=True),
         Field(["name", "type_name"], index=True),
         Field("implements", t=List, subtype=TypeReference, default=[]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("description"),
         Field("reducible_to_key", t=Unicode, link_to_parent=True),
     ]
@@ -78,6 +94,8 @@ class TypeRecord(Parsable):
         self.attributes = TypeAttributes()
         self.description = None
         self.reducible_to_key = None
+        self.parameters = None
+        self.generic_type = None
 
     def get_fields(self, *args):
         for arg in args:
@@ -85,7 +103,7 @@ class TypeRecord(Parsable):
                 if sub_item.key.lower() == arg.lower():
                     return sub_item
 
-
+class TypeParameters(Parsable): pass
 class TypeAbstract(Parsable):
     """
     Class defining "Abstract" type in IST
@@ -96,12 +114,11 @@ class TypeAbstract(Parsable):
     :type description        : unicode
     :type implementations    : List[ist.extras.TypeReference]
     :type default_descendant : ist.extras.TypeReference
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
+    __fields__ = base_fields + [
         Field(["name", "type_name"], index=True),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("description"),
         Field("implementations", t=List, subtype=TypeReference, default=[]),
         Field("default_descendant", t=TypeReference),
@@ -116,6 +133,8 @@ class TypeAbstract(Parsable):
         self.description = None
         self.implementations = None
         self.default_descendant = None
+        self.parameters = None
+        self.generic_type = None
 
 
 class TypeString(Parsable):
@@ -125,13 +144,10 @@ class TypeString(Parsable):
     :type name               : unicode
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
-        Field(["name", "type_name"]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
-    ]
+    __fields__ = simple_fields
 
     def __init__(self):
         super(TypeString, self).__init__()
@@ -139,6 +155,8 @@ class TypeString(Parsable):
         self.name = None
         self.input_type = None
         self.attributes = None
+        self.parameters = None
+        self.generic_type = None
 
 
 class TypeDouble(Parsable):
@@ -149,13 +167,11 @@ class TypeDouble(Parsable):
     :type name               : unicode
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
+    __fields__ = simple_fields + [
         Field("range", t=TypeRange),
-        Field(["name", "type_name"]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -165,6 +181,8 @@ class TypeDouble(Parsable):
         self.name = None
         self.input_type = None
         self.attributes = None
+        self.parameters = None
+        self.generic_type = None
 
 
 class TypeFilename(Parsable):
@@ -175,13 +193,11 @@ class TypeFilename(Parsable):
     :type file_mode          : unicode
     :type attributes         : ist.extras.TypeAttributes
     :type input_type         : InputType
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
-        Field(["name", "type_name"]),
+    __fields__ = simple_fields + [
         Field("file_mode"),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
-        Field("input_type", t=InputType),
     ]
 
     def __init__(self):
@@ -191,6 +207,8 @@ class TypeFilename(Parsable):
         self.file_mode = None
         self.attributes = None
         self.input_type = None
+        self.parameters = None
+        self.generic_type = None
 
 
 class TypeBool(Parsable):
@@ -200,13 +218,10 @@ class TypeBool(Parsable):
     :type name               : unicode
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
-        Field(["name", "type_name"]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
-    ]
+    __fields__ = simple_fields
 
     def __init__(self):
         super(TypeBool, self).__init__()
@@ -214,6 +229,8 @@ class TypeBool(Parsable):
         self.name = None
         self.input_type = None
         self.attributes = None
+        self.parameters = None
+        self.generic_type = None
 
 
 class TypeInteger(Parsable):
@@ -224,13 +241,11 @@ class TypeInteger(Parsable):
     :type name               : unicode
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
+    __fields__ = simple_fields + [
         Field("range", t=TypeRange),
-        Field(["name", "type_name"]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -240,6 +255,8 @@ class TypeInteger(Parsable):
         self.name = None
         self.input_type = None
         self.attributes = None
+        self.parameters = None
+        self.generic_type = None
 
 
 class TypeArray(Parsable):
@@ -251,14 +268,12 @@ class TypeArray(Parsable):
     :type name               : unicode
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
+    __fields__ = simple_fields + [
         Field("range", t=TypeRange),
         Field("subtype", t=TypeReference),
-        Field(["name", "type_name"]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -269,7 +284,8 @@ class TypeArray(Parsable):
         self.name = None
         self.input_type = None
         self.attributes = None
-
+        self.parameters = None
+        self.generic_type = None
 
 class TypeParameter(Parsable):
     """
@@ -278,13 +294,10 @@ class TypeParameter(Parsable):
     :type name               : unicode
     :type input_type         : InputType
     :type attributes         : ist.extras.TypeAttributes
+    :type parameters         : list[TypeAttributeParameter]
+    :type generic_type       : ist.extras.TypeReference
     """
-    __fields__ = [
-        Field("id", index=True),
-        Field(["name", "type_name"]),
-        Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
-    ]
+    __fields__ = simple_fields
 
     def __init__(self):
         super(TypeParameter, self).__init__()
@@ -292,3 +305,5 @@ class TypeParameter(Parsable):
         self.name = None
         self.input_type = None
         self.attributes = None
+        self.parameters = None
+        self.generic_type = None

--- a/src/python/ist/nodes.py
+++ b/src/python/ist/nodes.py
@@ -19,10 +19,10 @@ class TypeSelection(Parsable):
     """
     __fields__ = [
         Field("id", index=True),
-        Field("values", t=List, subtype=TypeSelectionValue, link_to_parent=True),
+        Field("values", t=List, subtype=TypeSelectionValue, link_to_parent=True, default=[]),
         Field(["name", "type_name"], index=True),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("description"),
     ]
 
@@ -49,7 +49,7 @@ class TypeRecord(Parsable):
     """
     Class defining "Record" type in IST
     :type id                 : unicode
-    :type keys               : list[ist.extras.TypeRecordKey]
+    :type keys               : List[ist.extras.TypeRecordKey]
     :type name               : unicode
     :type implements         : List[ist.extras.TypeReference]
     :type input_type         : InputType
@@ -61,9 +61,9 @@ class TypeRecord(Parsable):
         Field("id", index=True),
         Field("keys", t=List, subtype=TypeRecordKey, link_to_parent=True),
         Field(["name", "type_name"], index=True),
-        Field("implements", t=List, subtype=TypeReference),
+        Field("implements", t=List, subtype=TypeReference, default=[]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("description"),
         Field("reducible_to_key", t=Unicode, link_to_parent=True),
     ]
@@ -71,11 +71,11 @@ class TypeRecord(Parsable):
     def __init__(self):
         super(TypeRecord, self).__init__()
         self.id = None
-        self.keys = None
+        self.keys = []
         self.name = None
-        self.implements = None
+        self.implements = []
         self.input_type = None
-        self.attributes = None
+        self.attributes = TypeAttributes()
         self.description = None
         self.reducible_to_key = None
 
@@ -101,9 +101,9 @@ class TypeAbstract(Parsable):
         Field("id", index=True),
         Field(["name", "type_name"], index=True),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("description"),
-        Field("implementations", t=List, subtype=TypeReference),
+        Field("implementations", t=List, subtype=TypeReference, default=[]),
         Field("default_descendant", t=TypeReference),
     ]
 
@@ -130,7 +130,7 @@ class TypeString(Parsable):
         Field("id", index=True),
         Field(["name", "type_name"]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -155,7 +155,7 @@ class TypeDouble(Parsable):
         Field("range", t=TypeRange),
         Field(["name", "type_name"]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -180,7 +180,7 @@ class TypeFilename(Parsable):
         Field("id", index=True),
         Field(["name", "type_name"]),
         Field("file_mode"),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
         Field("input_type", t=InputType),
     ]
 
@@ -205,7 +205,7 @@ class TypeBool(Parsable):
         Field("id", index=True),
         Field(["name", "type_name"]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -230,7 +230,7 @@ class TypeInteger(Parsable):
         Field("range", t=TypeRange),
         Field(["name", "type_name"]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -258,7 +258,7 @@ class TypeArray(Parsable):
         Field("subtype", t=TypeReference),
         Field(["name", "type_name"]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):
@@ -283,7 +283,7 @@ class TypeParameter(Parsable):
         Field("id", index=True),
         Field(["name", "type_name"]),
         Field("input_type", t=InputType),
-        Field("attributes", t=TypeAttributes),
+        Field("attributes", t=TypeAttributes, default=TypeAttributes()),
     ]
 
     def __init__(self):


### PR DESCRIPTION
major changes:
 - add default values for ist formatter
 - default values for more complex types allowing omitting tags in IST (such as empty `"attributes": {}`)
 - extract `generic_type` and `parameters` from `attributes`
 - prepare for new ist changes (list -> dict replacement) in `attributes`, e.g.:
```js

`attributes`: [ { }, { }, { } ] 

`attributes`: { , , , }
```