### PR TITLE
Pe output

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(coupling_lib
     io/output_time.cc
     io/output_vtk.cc
     io/output_msh.cc
+    io/output_mesh.cc
     
     fields/field_values.cc
     fields/field_common.cc

--- a/src/fields/field_set.cc
+++ b/src/fields/field_set.cc
@@ -168,6 +168,12 @@ bool FieldSet::is_jump_time() const {
 
 void FieldSet::output(std::shared_ptr<OutputTime> stream) {
 	START_TIMER("Fill OutputData");
+    
+    // TODO: remove const_cast after resolving problems with const Mesh.
+    Mesh *field_mesh = const_cast<Mesh *>(field_list[0]->mesh());
+    DBGMSG("call make output stream\n");
+    stream->make_output_mesh(field_mesh, this);
+    
     for(auto field : field_list)
         if ( !field->is_bc() && field->flags().match( FieldFlag::allow_output) )
             field->output(stream);

--- a/src/io/output_element.hh
+++ b/src/io/output_element.hh
@@ -32,7 +32,7 @@ class ElementAccessor;
 /** @brief Represents an element of the output mesh.
  * Provides element access on the data of the output mesh (nodes, connectivity, offsets etc.).
  * 
- * Vertex function suppose spacedim = 3 at the moment.
+ * Vertex function suppose spacedim = 3 at the moment, hard coded.
  */
 class OutputElement
 {
@@ -43,7 +43,7 @@ public:
     typedef Space<spacedim>::Point Point;
     
     /// Constructor.
-    OutputElement(unsigned int ele_idx, OutputMesh* output_mesh);
+    OutputElement(unsigned int ele_idx, std::shared_ptr<OutputMeshBase> output_mesh);
     
     /// @name Output Mesh Getters.
     //@{ 
@@ -54,17 +54,7 @@ public:
     /// Returns global index of the node.
     unsigned int node_index(unsigned int loc_idx) const;
     Point vertex(unsigned int loc_idx) const;  ///< Returns coordinates of node @p loc_idx.
-    std::vector<Point> vertex_list() const;    ///< Returns vector of nodes coordinates.
-    
-    /// Returns global index of the node. (DISCONTINOUS)
-    unsigned int node_index_disc(unsigned int loc_idx) const;
-    
-    //TODO: vertex_disc and vertex_list_disc return the same coordinates as vertex and vertex_list
-    // It is meaningful only if we have ONLY discontinuous vectors for nodes and connectivity
-    /// Returns coordinates of node @p loc_idx. (DISCONTINOUS)
-    Point vertex_disc(unsigned int loc_idx) const;
-    /// Returns vector of nodes coordinates. (DISCONTINOUS)
-    std::vector<Point> vertex_list_disc() const;
+    std::vector<Point> vertex_list() const;    ///< Returns vector of nodes coordinates.    
     
     Point centre() const;                      ///< Computes the barycenter.
     //@}
@@ -79,33 +69,23 @@ public:
     ElementAccessor<spacedim> element_accessor() const;
     //@}
     
-    void operator++();
+    void inc();
     bool operator==(const OutputElement& other);
 private:
     
-    /// Returns global index of the node. (DISCONTINUOUS)
-    unsigned int node_index_internal(unsigned int loc_idx, 
-                                     std::shared_ptr<MeshData<unsigned int>> connectivity) const;
-    /// Returns coordinates of node @p loc_idx.  (DISCONTINUOUS)
-    Point vertex_internal(unsigned int loc_idx,
-                               std::shared_ptr<MeshData<unsigned int>> connectivity,
-                               std::shared_ptr<MeshData<double>> nodes) const;
-    /// Returns vector of nodes coordinates.  (DISCONTINUOUS)
-    std::vector<Point> vertex_list_internal(std::shared_ptr<MeshData<unsigned int>> connectivity,
-                                            std::shared_ptr<MeshData<double>> nodes) const;
-    
-//     friend void OutputElementIterator::operator++();
-    unsigned int ele_idx_;      ///< index of the output element
-    OutputMesh* output_mesh_;   ///< pointer to the output mesh
+    /// index of the output element
+    unsigned int ele_idx_;
+    /// pointer to the output mesh
+    std::shared_ptr<OutputMeshBase> output_mesh_;
 };
 
 // --------------------------------------------------- OutputElement INLINE implementation -------------------
 
-inline OutputElement::OutputElement(unsigned int ele_idx, OutputMesh* output_mesh)
+inline OutputElement::OutputElement(unsigned int ele_idx, std::shared_ptr<OutputMeshBase> output_mesh)
 : ele_idx_(ele_idx), output_mesh_(output_mesh)
 {}
 
-inline void OutputElement::operator++()
+inline void OutputElement::inc()
 {
     ele_idx_++;
 }
@@ -150,75 +130,43 @@ inline unsigned int OutputElement::dim() const
     return n_nodes()-1;
 }
 
-inline unsigned int OutputElement::node_index_internal(unsigned int loc_idx,
-                                                shared_ptr< MeshData< unsigned int > > connectivity) const
+
+inline unsigned int OutputElement::node_index(unsigned int loc_idx) const
 {
     unsigned int n = n_nodes();
     ASSERT_DBG(loc_idx < n);
     unsigned int con_off = (*output_mesh_->offsets_)[ele_idx_];
-    return (*connectivity)[con_off - n + loc_idx];
+    return (* output_mesh_->connectivity_)[con_off - n + loc_idx];
 }
 
-inline OutputElement::Point OutputElement::vertex_internal(unsigned int loc_idx,
-                                                 shared_ptr< MeshData< unsigned int > > connectivity,
-                                                 shared_ptr< MeshData< double > > nodes) const
+
+inline OutputElement::Point OutputElement::vertex(unsigned int loc_idx) const
 {
     unsigned int n = n_nodes();
     ASSERT_DBG(loc_idx < n);
     unsigned int con_off = (*output_mesh_->offsets_)[ele_idx_];
-    unsigned int off = spacedim * (*connectivity)[con_off - n + loc_idx];
-    auto &d = nodes->data_;
+    unsigned int off = spacedim * (* output_mesh_->connectivity_)[con_off - n + loc_idx];
+    auto &d = output_mesh_->nodes_->data_;
     Point point({d[off], d[off+1], d[off+2]});
     return point;
 }
 
-inline std::vector< OutputElement::Point > OutputElement::vertex_list_internal(shared_ptr< MeshData< unsigned int > > connectivity, 
-                                                                               shared_ptr< MeshData< double > > nodes) const
+
+inline std::vector< OutputElement::Point > OutputElement::vertex_list() const
 {
     const unsigned int n = n_nodes();
     std::vector<Point> vertices(n);
     
     unsigned int con_off = (*output_mesh_->offsets_)[ele_idx_];
-    auto &d = nodes->data_;
+    auto &d = output_mesh_->nodes_->data_;
     for(unsigned int i=0; i<n; i++) {
-        unsigned int off = spacedim * (*connectivity)[con_off - n + i];
+        unsigned int off = spacedim * (* output_mesh_->connectivity_)[con_off - n + i];
         vertices[i] = {d[off], d[off+1], d[off+2]};
         off += spacedim;
     }
     return vertices;
 }
 
-
-inline unsigned int OutputElement::node_index(unsigned int loc_idx) const
-{
-    return node_index_internal(loc_idx, output_mesh_->connectivity_);
-}
-
-inline unsigned int OutputElement::node_index_disc(unsigned int loc_idx) const
-{
-    ASSERT_PTR(output_mesh_->discont_connectivity_);
-    return node_index_internal(loc_idx, output_mesh_->discont_connectivity_);
-}
-
-inline OutputElement::Point OutputElement::vertex(unsigned int loc_idx) const
-{
-    return vertex_internal(loc_idx, output_mesh_->connectivity_, output_mesh_->nodes_);
-}
-
-inline OutputElement::Point OutputElement::vertex_disc(unsigned int loc_idx) const
-{
-    return vertex_internal(loc_idx, output_mesh_->discont_connectivity_, output_mesh_->discont_nodes_);
-}
-
-inline std::vector< OutputElement::Point > OutputElement::vertex_list() const
-{
-    return vertex_list_internal(output_mesh_->connectivity_, output_mesh_->nodes_);
-}
-
-inline std::vector< OutputElement::Point > OutputElement::vertex_list_disc() const
-{
-    return vertex_list_internal(output_mesh_->discont_connectivity_, output_mesh_->discont_nodes_);
-}
 
 inline OutputElement::Point OutputElement::centre() const
 {

--- a/src/io/output_element.hh
+++ b/src/io/output_element.hh
@@ -1,0 +1,284 @@
+/*!
+ *
+﻿ * Copyright (C) 2015 Technical University of Liberec.  All rights reserved.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3 as published by the
+ * Free Software Foundation. (http://www.gnu.org/licenses/gpl-3.0.en.html)
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * 
+ * @file    output_element.hh
+ * @brief   Class OutputElement and its iterator OutputElementIterator on the output mesh.
+ */
+
+#ifndef OUTPUT_ELEMENT_HH_
+#define OUTPUT_ELEMENT_HH_
+
+#include "output_mesh.hh"
+
+template <int spacedim>
+class ElementAccessor;
+
+
+#include "mesh/accessors.hh"
+#include "mesh/mesh.h"
+#include "output_mesh.hh"
+
+
+/** @brief Represents an element of the output mesh.
+ * Provides element access on the data of the output mesh (nodes, connectivity, offsets etc.).
+ */
+class OutputElement
+{
+public:
+    /// Element space dimension = 3.
+    static const unsigned int spacedim = 3;
+    
+    OutputElement(unsigned int ele_idx, OutputMesh* output_mesh);
+    
+    /// @name Output Mesh Getters.
+    //@{ 
+    unsigned int idx() const;                       ///< Returns index of the output element.
+    unsigned int n_nodes() const;                   ///< Returns number of nodes.
+    unsigned int dim() const;                       ///< Returns dim of the output element.
+    
+    /// Returns global index of the node.
+    unsigned int node_index(unsigned int loc_idx) const;
+    arma::vec3 vertex(unsigned int loc_idx) const;  ///< Returns coordinates of node @p loc_idx.
+    std::vector<arma::vec3> vertex_list() const;    ///< Returns vector of nodes coordinates.
+    
+    /// Returns global index of the node. (DISCONTINOUS)
+    unsigned int node_index_disc(unsigned int loc_idx) const;
+    
+    //TODO: vertex_disc and vertex_list_disc return the same coordinates as vertex and vertex_list
+    // It is meaningful only if we have ONLY discontinuous vectors for nodes and connectivity
+    /// Returns coordinates of node @p loc_idx. (DISCONTINOUS)
+    arma::vec3 vertex_disc(unsigned int loc_idx) const;
+    /// Returns vector of nodes coordinates. (DISCONTINOUS)
+    std::vector<arma::vec3> vertex_list_disc() const;
+    
+    arma::vec3 centre() const;                      ///< Computes the barycenter.
+    //@}
+    
+    /// @name Output Mesh Getters.
+    //@{ 
+    /// Returns pointer to the computational mesh.
+    Mesh* orig_mesh();
+    /// Returns index of the master element in the computational mesh.
+    unsigned int orig_element_idx() const;
+    ///Gets ElementAccessor of this element
+    ElementAccessor<spacedim> element_accessor() const;
+    //@}
+    
+    void inc();
+private:
+    
+    /// Returns global index of the node. (DISCONTINUOUS)
+    unsigned int node_index_internal(unsigned int loc_idx, 
+                                     std::shared_ptr<MeshData<unsigned int>> connectivity) const;
+    /// Returns coordinates of node @p loc_idx.  (DISCONTINUOUS)
+    arma::vec3 vertex_internal(unsigned int loc_idx,
+                               std::shared_ptr<MeshData<unsigned int>> connectivity,
+                               std::shared_ptr<MeshData<double>> nodes) const;
+    /// Returns vector of nodes coordinates.  (DISCONTINUOUS)
+    std::vector<arma::vec3> vertex_list_internal(std::shared_ptr<MeshData<unsigned int>> connectivity,
+                                                 std::shared_ptr<MeshData<double>> nodes) const;
+    
+//     friend void OutputElementIterator::operator++();
+    unsigned int ele_idx_;      ///< index of the output element
+    OutputMesh* output_mesh_;   ///< pointer to the output mesh
+};
+
+// --------------------------------------------------- OutputElement INLINE implementation -------------------
+
+inline OutputElement::OutputElement(unsigned int ele_idx, OutputMesh* output_mesh)
+: ele_idx_(ele_idx), output_mesh_(output_mesh)
+{}
+
+inline void OutputElement::inc()
+{
+    ele_idx_++;
+}
+
+
+inline Mesh* OutputElement::orig_mesh()
+{
+    return output_mesh_->orig_mesh_;
+}
+
+inline unsigned int OutputElement::orig_element_idx() const
+{
+    return (*output_mesh_->orig_element_indices_)[ele_idx_];
+}
+
+inline ElementAccessor< OutputElement::spacedim > OutputElement::element_accessor() const
+{
+    return output_mesh_->orig_mesh_->element_accessor(orig_element_idx());
+}
+
+
+inline unsigned int OutputElement::idx() const
+{
+    return ele_idx_;
+}
+
+inline unsigned int OutputElement::n_nodes() const
+{
+    if(ele_idx_ == 0)
+        return (*output_mesh_->offsets_)[0];
+    else
+        return (*output_mesh_->offsets_)[ele_idx_] - (*output_mesh_->offsets_)[ele_idx_-1];
+}
+
+inline unsigned int OutputElement::dim() const
+{
+    return n_nodes()-1;
+}
+
+inline unsigned int OutputElement::node_index_internal(unsigned int loc_idx,
+                                                shared_ptr< MeshData< unsigned int > > connectivity) const
+{
+    unsigned int n = n_nodes();
+    ASSERT_DBG(loc_idx < n);
+    unsigned int con_off = (*output_mesh_->offsets_)[ele_idx_];
+    return (*connectivity)[con_off - n + loc_idx];
+}
+
+inline arma::vec3 OutputElement::vertex_internal(unsigned int loc_idx,
+                                                 shared_ptr< MeshData< unsigned int > > connectivity,
+                                                 shared_ptr< MeshData< double > > nodes) const
+{
+    unsigned int n = n_nodes();
+    ASSERT_DBG(loc_idx < n);
+    unsigned int con_off = (*output_mesh_->offsets_)[ele_idx_];
+    unsigned int off = spacedim * (*connectivity)[con_off - n + loc_idx];
+    auto &d = nodes->data_;
+    arma::vec3 point({d[off], d[off+1], d[off+2]});
+    return point;
+}
+
+inline std::vector< arma::vec3 > OutputElement::vertex_list_internal(shared_ptr< MeshData< unsigned int > > connectivity, 
+                                                                     shared_ptr< MeshData< double > > nodes) const
+{
+    const unsigned int n = n_nodes();
+    std::vector<arma::vec3> vertices(n);
+    
+    unsigned int con_off = (*output_mesh_->offsets_)[ele_idx_];
+    auto &d = nodes->data_;
+    for(unsigned int i=0; i<n; i++) {
+        unsigned int off = spacedim * (*connectivity)[con_off - n + i];
+        vertices[i] = {d[off], d[off+1], d[off+2]};
+        off += spacedim;
+    }
+    return vertices;
+}
+
+
+inline unsigned int OutputElement::node_index(unsigned int loc_idx) const
+{
+    return node_index_internal(loc_idx, output_mesh_->connectivity_);
+}
+
+inline unsigned int OutputElement::node_index_disc(unsigned int loc_idx) const
+{
+    ASSERT_DBG(output_mesh_->discont_data_computed_);
+    return node_index_internal(loc_idx, output_mesh_->discont_connectivity_);
+}
+
+inline arma::vec3 OutputElement::vertex(unsigned int loc_idx) const
+{
+    return vertex_internal(loc_idx, output_mesh_->connectivity_, output_mesh_->nodes_);
+}
+
+inline arma::vec3 OutputElement::vertex_disc(unsigned int loc_idx) const
+{
+    return vertex_internal(loc_idx, output_mesh_->discont_connectivity_, output_mesh_->discont_nodes_);
+}
+
+inline std::vector< arma::vec3 > OutputElement::vertex_list() const
+{
+    return vertex_list_internal(output_mesh_->connectivity_, output_mesh_->nodes_);
+}
+
+inline std::vector< arma::vec3 > OutputElement::vertex_list_disc() const
+{
+    return vertex_list_internal(output_mesh_->discont_connectivity_, output_mesh_->discont_nodes_);
+}
+
+inline arma::vec3 OutputElement::centre() const
+{
+    arma::vec3 res({0,0,0});
+    for(auto& v : vertex_list() ) res += v;
+    return res/n_nodes();
+}
+
+// --------------------------------------------------- OutputElementIterator ---------------------------------
+/** @brief Output element iterator.
+ * Provides iterator over elements of the output mesh.
+ */
+class OutputElementIterator
+{
+public:
+//     OutputElementIterator();
+
+    OutputElementIterator(const OutputElement& output_element);
+
+    /// equal operator
+    bool operator==(const OutputElementIterator& other);
+    /// non-equal operator
+    bool operator!=(const OutputElementIterator& other);
+
+    ///  * dereference operator
+    const OutputElement& operator*() const;
+
+    /// -> dereference operator
+    const OutputElement* operator->() const;
+
+    /// prefix increment
+    OutputElementIterator& operator++();
+
+private:
+    /// Output element of the output mesh.
+    OutputElement element_; 
+};
+
+
+// --------------------------------------------------- OutputElementIterator INLINE implementation -----------
+// inline OutputElementIterator::OutputElementIterator()
+// {}
+
+inline OutputElementIterator::OutputElementIterator(const OutputElement& output_element)
+: element_(output_element)
+{}
+
+inline bool OutputElementIterator::operator==(const OutputElementIterator& other)
+{
+    return (element_.idx() == other.element_.idx());
+}
+
+inline bool OutputElementIterator::operator!=(const OutputElementIterator& other)
+{
+    return !( *this == other);
+}
+
+inline const OutputElement& OutputElementIterator::operator*() const
+{
+    return element_;
+}
+
+inline const OutputElement* OutputElementIterator::operator->() const
+{
+    return &element_;
+}
+
+inline OutputElementIterator& OutputElementIterator::operator++()
+{
+    element_.inc();
+    return (*this);
+}
+
+#endif // OUTPUT_ELEMENT_HH_

--- a/src/io/output_element.hh
+++ b/src/io/output_element.hh
@@ -29,7 +29,6 @@ class ElementAccessor;
 #include "mesh/point.hh"
 #include "output_mesh.hh"
 
-
 /** @brief Represents an element of the output mesh.
  * Provides element access on the data of the output mesh (nodes, connectivity, offsets etc.).
  * 
@@ -80,7 +79,8 @@ public:
     ElementAccessor<spacedim> element_accessor() const;
     //@}
     
-    void inc();
+    void operator++();
+    bool operator==(const OutputElement& other);
 private:
     
     /// Returns global index of the node. (DISCONTINUOUS)
@@ -105,9 +105,14 @@ inline OutputElement::OutputElement(unsigned int ele_idx, OutputMesh* output_mes
 : ele_idx_(ele_idx), output_mesh_(output_mesh)
 {}
 
-inline void OutputElement::inc()
+inline void OutputElement::operator++()
 {
     ele_idx_++;
+}
+
+inline bool OutputElement::operator==(const OutputElement& other)
+{
+    return ele_idx_ == other.ele_idx_;
 }
 
 
@@ -220,71 +225,6 @@ inline OutputElement::Point OutputElement::centre() const
     Point res({0,0,0});
     for(auto& v : vertex_list() ) res += v;
     return res/n_nodes();
-}
-
-// --------------------------------------------------- OutputElementIterator ---------------------------------
-/** @brief Output element iterator.
- * Provides iterator over elements of the output mesh.
- */
-class OutputElementIterator
-{
-public:
-//     OutputElementIterator();
-
-    OutputElementIterator(const OutputElement& output_element);
-
-    /// equal operator
-    bool operator==(const OutputElementIterator& other);
-    /// non-equal operator
-    bool operator!=(const OutputElementIterator& other);
-
-    ///  * dereference operator
-    const OutputElement& operator*() const;
-
-    /// -> dereference operator
-    const OutputElement* operator->() const;
-
-    /// prefix increment
-    OutputElementIterator& operator++();
-
-private:
-    /// Output element of the output mesh.
-    OutputElement element_; 
-};
-
-
-// --------------------------------------------------- OutputElementIterator INLINE implementation -----------
-// inline OutputElementIterator::OutputElementIterator()
-// {}
-
-inline OutputElementIterator::OutputElementIterator(const OutputElement& output_element)
-: element_(output_element)
-{}
-
-inline bool OutputElementIterator::operator==(const OutputElementIterator& other)
-{
-    return (element_.idx() == other.element_.idx());
-}
-
-inline bool OutputElementIterator::operator!=(const OutputElementIterator& other)
-{
-    return !( *this == other);
-}
-
-inline const OutputElement& OutputElementIterator::operator*() const
-{
-    return element_;
-}
-
-inline const OutputElement* OutputElementIterator::operator->() const
-{
-    return &element_;
-}
-
-inline OutputElementIterator& OutputElementIterator::operator++()
-{
-    element_.inc();
-    return (*this);
 }
 
 #endif // OUTPUT_ELEMENT_HH_

--- a/src/io/output_element.hh
+++ b/src/io/output_element.hh
@@ -196,7 +196,7 @@ inline unsigned int OutputElement::node_index(unsigned int loc_idx) const
 
 inline unsigned int OutputElement::node_index_disc(unsigned int loc_idx) const
 {
-    ASSERT_DBG(output_mesh_->discont_data_computed_);
+    ASSERT_PTR(output_mesh_->discont_connectivity_);
     return node_index_internal(loc_idx, output_mesh_->discont_connectivity_);
 }
 

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -17,22 +17,29 @@
 
 #include "output_mesh.hh"
 #include "mesh/mesh.h"
+#include "fields/field.hh"
+
 
 OutputMesh::OutputMesh(Mesh* mesh)
 : orig_mesh_(mesh), discont_data_computed_(false)
 {
-    DBGMSG("create outputmesh\n");
-    nodes_ = std::make_shared<MeshData<double>>("", OutputDataBase::N_VECTOR);
-    connectivity_ = std::make_shared<MeshData<unsigned int>>("connectivity");
-    offsets_ = std::make_shared<MeshData<unsigned int>>("offsets");
-    
-    fill_vectors();
-    DBGMSG("create outputmesh\n");
 }
 
 OutputMesh::~OutputMesh()
 {
 }
+
+
+void OutputMesh::create_identical_mesh()
+{
+//     DBGMSG("create identical outputmesh\n");
+    nodes_ = std::make_shared<MeshData<double>>("", OutputDataBase::N_VECTOR);
+    connectivity_ = std::make_shared<MeshData<unsigned int>>("connectivity");
+    offsets_ = std::make_shared<MeshData<unsigned int>>("offsets");
+    
+    fill_vectors();
+}
+
 
 
 void OutputMesh::fill_vectors()
@@ -111,4 +118,63 @@ void OutputMesh::compute_discontinuous_data()
     }
     
     discont_data_computed_ = true;
+}
+
+
+void OutputMesh::create_refined_mesh(Field<3, FieldValue<3>::Scalar> *error_control_field)
+{
+    ASSERT(0).error("Not implemented yet.");
+    
+    orig_element_indices_ = std::make_shared<std::vector<unsigned int>>();
+    local_nodes_ = std::make_shared<std::vector<double>>();
+    
+    //FIXME: suggest required capacity
+    unsigned int capacity = 16*orig_mesh_->n_elements();
+    orig_element_indices_->reserve(capacity);
+    local_nodes_->reserve(3*capacity);
+    
+    // create node indices for connectivity
+    unsigned int node_id = 0;   // node id
+    FOR_NODES(orig_mesh_, node) {
+        node->aux = node_id;   // store node index in the auxiliary variable
+        node_id++;
+    }
+    
+    FOR_ELEMENTS(orig_mesh_, ele) {
+        arma::vec3 centre = ele->centre();
+        
+        AuxElement aux_ele;
+        aux_ele.connectivity.resize(ele->n_nodes());
+        aux_ele.coords.resize(ele->n_nodes()*3);
+        for(unsigned int i=0; i<ele->n_nodes(); i++)
+        {
+            Node* node = ele->node[i];
+            aux_ele.connectivity[i] = node->aux;
+            aux_ele.coords[i] = node->getX();
+            aux_ele.coords[i+1] = node->getY();
+            aux_ele.coords[i+2] = node->getZ();
+        }
+        
+        //refinement refinement
+        // if(refinement_criterion())
+        {
+            // new element:
+            // centre + combination of dim nodes from all nodes
+            static const std::vector<std::vector<std::vector<unsigned int>>> side_permutations = 
+                {   { {0},{1}}, // line
+                    { {0,1}, {0,2}, {1,2}}, //triangle
+                    { {0,1,2}, {0,1,3}, {0,2,3}, {1,2,3}}   //tetrahedron
+                };
+            
+        }
+    }
+    
+    orig_element_indices_->shrink_to_fit();
+    local_nodes_->shrink_to_fit();
+}
+
+
+bool OutputMesh::refinement_criterion()
+{
+
 }

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -19,6 +19,7 @@
 #include "mesh/mesh.h"
 #include "fields/field.hh"
 
+#include "output_element.hh"
 
 OutputMesh::OutputMesh(Mesh* mesh)
 : orig_mesh_(mesh), discont_data_computed_(false)
@@ -29,6 +30,15 @@ OutputMesh::~OutputMesh()
 {
 }
 
+OutputElementIterator OutputMesh::begin()
+{
+    return OutputElementIterator(OutputElement(0, this));
+}
+
+OutputElementIterator OutputMesh::end()
+{
+    return OutputElementIterator(OutputElement(offsets_->n_values, this));
+}
 
 void OutputMesh::create_identical_mesh()
 {
@@ -60,7 +70,7 @@ void OutputMesh::fill_vectors()
         node_id++;
     }
     
-    
+    orig_element_indices_ = std::make_shared<std::vector<unsigned int>>(n_elements);
     connectivity_->data_.reserve(4*n_elements);  //reserve - suppose all elements being tetrahedra (4 nodes)
     offsets_->data_.resize(n_elements);
     offsets_->n_values = n_elements;
@@ -79,6 +89,7 @@ void OutputMesh::fill_vectors()
         // increase offset by number of nodes of the simplicial element
         offset += ele->dim() + 1;
         offsets_->data_[ele_id] = offset;
+        (*orig_element_indices_)[ele_id] = ele_id;
         ele_id++;
     }
     connectivity_->data_.shrink_to_fit();

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -141,10 +141,10 @@ void OutputMesh::compute_discontinuous_data()
                  corner_id = 0, // corner index (discontinous node)
                  li;            // local node index
 
-    for(OutputElementIterator it = begin(); it != end(); ++it)
+    for(const auto & ele : *output_mesh_)
     {
-        unsigned int n = it->n_nodes(), 
-                     ele_idx = it->idx(),
+        unsigned int n = ele.n_nodes(), 
+                     ele_idx = ele.idx(),
                      con_off = (*offsets_)[ele_idx];
                      
         for(li = 0; li < n; li++)

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -19,13 +19,14 @@
 #include "mesh/mesh.h"
 
 OutputMesh::OutputMesh(Mesh* mesh)
+: orig_mesh_(mesh), discont_data_computed_(false)
 {
     DBGMSG("create outputmesh\n");
-    nodes_ = std::make_shared<MeshData<double>>("nodes", OutputDataBase::N_VECTOR);
+    nodes_ = std::make_shared<MeshData<double>>("", OutputDataBase::N_VECTOR);
     connectivity_ = std::make_shared<MeshData<unsigned int>>("connectivity");
     offsets_ = std::make_shared<MeshData<unsigned int>>("offsets");
     
-    fill_vectors(mesh);
+    fill_vectors();
     DBGMSG("create outputmesh\n");
 }
 
@@ -34,16 +35,16 @@ OutputMesh::~OutputMesh()
 }
 
 
-void OutputMesh::fill_vectors(Mesh* mesh)
+void OutputMesh::fill_vectors()
 {
-    const unsigned int n_elements = mesh->n_elements(),
-                       n_nodes = mesh->n_nodes();
+    const unsigned int n_elements = orig_mesh_->n_elements(),
+                       n_nodes = orig_mesh_->n_nodes();
 
     nodes_->data_.resize(3*n_nodes);    // suppose 3D coordinates
     nodes_->n_values = n_nodes;
     unsigned int coord_id = 0,  // coordinate id in vector
                  node_id = 0;   // node id
-    FOR_NODES(mesh, node) {
+    FOR_NODES(orig_mesh_, node) {
         node->aux = node_id;   // store node index in the auxiliary variable
 
         nodes_->data_[coord_id] = node->getX();  coord_id++;
@@ -59,120 +60,55 @@ void OutputMesh::fill_vectors(Mesh* mesh)
     Node* node;
     unsigned int ele_id = 0,
                  connect_id = 0,
-                 offset = 0,    //offset of node indices of element in node vector
-                 li;            //local node index
-    FOR_ELEMENTS(mesh, ele) {
+                 offset = 0,    // offset of node indices of element in node vector
+                 li;            // local node index
+    FOR_ELEMENTS(orig_mesh_, ele) {
         FOR_ELEMENT_NODES(ele, li) {
             node = ele->node[li];
             connectivity_->data_.push_back(node->aux);
             connect_id++;
         }
         
+        // increase offset by number of nodes of the simplicial element
         offset += ele->dim() + 1;
         offsets_->data_[ele_id] = offset;
         ele_id++;
-        // increase offset by number of nodes of the simplicial element
     }
     connectivity_->data_.shrink_to_fit();
     connectivity_->n_values = connect_id;
 }
 
 
+void OutputMesh::compute_discontinuous_data()
+{
+    if(discont_data_computed_) return;
+    
+    discont_nodes_ = std::make_shared<MeshData<double>>("", OutputDataBase::N_VECTOR);
+    discont_connectivity_ = std::make_shared<MeshData<unsigned int>>("connectivity");
+    
+    const unsigned int n_corners = orig_mesh_->n_corners();
 
-// void OutputVTK::write_vtk_geometry(void)
-// {
-//     Mesh *mesh = this->_mesh;
-//     ofstream &file = this->_data_file;
-// 
-//     int tmp;
-// 
-//     /* Write Points begin*/
-//     file << "<Points>" << endl;
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">" << endl;
-//     /* Write own coordinates */
-//     tmp = 0;
-//     /* Set floating point precision */
-//     file.precision(std::numeric_limits<double>::digits10);
-//     FOR_NODES(mesh, node) {
-//         node->aux = tmp;   /* store index in the auxiliary variable */
-// 
-//         file << scientific << node->getX() << " ";
-//         file << scientific << node->getY() << " ";
-//         file << scientific << node->getZ() << " ";
-// 
-//         tmp++;
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-//     /* Write Points end*/
-//     file << "</Points>" << endl;
-// }
-// 
-// void OutputVTK::write_vtk_topology(void)
-// {
-//     Mesh *mesh = this->_mesh;
-//     ofstream &file = this->_data_file;
-// 
-//     Node* node;
-//     //ElementIter ele;
-//     unsigned int li;
-//     int tmp;
-// 
-//     /* Write Cells begin*/
-//     file << "<Cells>" << endl;
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">" << endl;
-//     /* Write own coordinates */
-//     FOR_ELEMENTS(mesh, ele) {
-//         FOR_ELEMENT_NODES(ele, li) {
-//             node = ele->node[li];
-//             file << node->aux << " ";   /* Write connectivity */
-//         }
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-// 
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"Int32\" Name=\"offsets\" format=\"ascii\">" << endl;
-//     /* Write number of nodes for each element */
-//     tmp = 0;
-//     FOR_ELEMENTS(mesh, ele) {
-//         switch(ele->dim()) {
-//         case 1:
-//             tmp += VTK_LINE_SIZE;
-//             break;
-//         case 2:
-//             tmp += VTK_TRIANGLE_SIZE;
-//             break;
-//         case 3:
-//             tmp += VTK_TETRA_SIZE;
-//             break;
-//         }
-//         file << tmp << " ";
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-// 
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">" << endl;
-//     /* Write type of nodes for each element */
-//     FOR_ELEMENTS(mesh, ele) {
-//         switch(ele->dim()) {
-//         case 1:
-//             file << (int)VTK_LINE << " ";
-//             break;
-//         case 2:
-//             file << (int)VTK_TRIANGLE << " ";
-//             break;
-//         case 3:
-//             file << (int)VTK_TETRA << " ";
-//             break;
-//         }
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-// 
-//     /* Write Cells end*/
-//     file << "</Cells>" << endl;
-// }
+    discont_nodes_->data_.resize(3*n_corners);    // suppose 3D coordinates
+    discont_nodes_->n_values = n_corners;
+ 
+    discont_connectivity_->data_.resize(n_corners);  //reserve - suppose all elements being tetrahedra (4 nodes)
+    discont_connectivity_->n_values = n_corners;
+    Node* node;
+    unsigned int coord_id = 0,  // coordinate id in vector
+                 corner_id = 0, // corner index (discontinous node)
+                 li;            // local node index
+    FOR_ELEMENTS(orig_mesh_, ele) {
+        FOR_ELEMENT_NODES(ele, li) {
+            node = ele->node[li];
+            
+            discont_nodes_->data_[coord_id] = node->getX();  coord_id++;
+            discont_nodes_->data_[coord_id] = node->getY();  coord_id++;
+            discont_nodes_->data_[coord_id] = node->getZ();  coord_id++;
+            
+            discont_connectivity_->data_[corner_id] = corner_id;
+            corner_id++;
+        }
+    }
+    
+    discont_data_computed_ = true;
+}

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -1,0 +1,178 @@
+/*!
+ *
+﻿ * Copyright (C) 2015 Technical University of Liberec.  All rights reserved.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3 as published by the
+ * Free Software Foundation. (http://www.gnu.org/licenses/gpl-3.0.en.html)
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * 
+ * @file    output_mesh.cc
+ * @brief   Classes for auxiliary output mesh.
+ */
+
+#include "output_mesh.hh"
+#include "mesh/mesh.h"
+
+OutputMesh::OutputMesh(Mesh* mesh)
+{
+    DBGMSG("create outputmesh\n");
+    nodes_ = std::make_shared<MeshData<double>>("nodes", OutputDataBase::N_VECTOR);
+    connectivity_ = std::make_shared<MeshData<unsigned int>>("connectivity");
+    offsets_ = std::make_shared<MeshData<unsigned int>>("offsets");
+    
+    fill_vectors(mesh);
+    DBGMSG("create outputmesh\n");
+}
+
+OutputMesh::~OutputMesh()
+{
+}
+
+
+void OutputMesh::fill_vectors(Mesh* mesh)
+{
+    const unsigned int n_elements = mesh->n_elements(),
+                       n_nodes = mesh->n_nodes();
+
+    nodes_->data_.resize(3*n_nodes);    // suppose 3D coordinates
+    nodes_->n_values = n_nodes;
+    unsigned int coord_id = 0,  // coordinate id in vector
+                 node_id = 0;   // node id
+    FOR_NODES(mesh, node) {
+        node->aux = node_id;   // store node index in the auxiliary variable
+
+        nodes_->data_[coord_id] = node->getX();  coord_id++;
+        nodes_->data_[coord_id] = node->getY();  coord_id++;
+        nodes_->data_[coord_id] = node->getZ();  coord_id++;
+        node_id++;
+    }
+    
+    
+    connectivity_->data_.reserve(4*n_elements);  //reserve - suppose all elements being tetrahedra (4 nodes)
+    offsets_->data_.resize(n_elements);
+    offsets_->n_values = n_elements;
+    Node* node;
+    unsigned int ele_id = 0,
+                 connect_id = 0,
+                 offset = 0,    //offset of node indices of element in node vector
+                 li;            //local node index
+    FOR_ELEMENTS(mesh, ele) {
+        FOR_ELEMENT_NODES(ele, li) {
+            node = ele->node[li];
+            connectivity_->data_.push_back(node->aux);
+            connect_id++;
+        }
+        
+        offset += ele->dim() + 1;
+        offsets_->data_[ele_id] = offset;
+        ele_id++;
+        // increase offset by number of nodes of the simplicial element
+    }
+    connectivity_->data_.shrink_to_fit();
+    connectivity_->n_values = connect_id;
+}
+
+
+
+// void OutputVTK::write_vtk_geometry(void)
+// {
+//     Mesh *mesh = this->_mesh;
+//     ofstream &file = this->_data_file;
+// 
+//     int tmp;
+// 
+//     /* Write Points begin*/
+//     file << "<Points>" << endl;
+//     /* Write DataArray begin */
+//     file << "<DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">" << endl;
+//     /* Write own coordinates */
+//     tmp = 0;
+//     /* Set floating point precision */
+//     file.precision(std::numeric_limits<double>::digits10);
+//     FOR_NODES(mesh, node) {
+//         node->aux = tmp;   /* store index in the auxiliary variable */
+// 
+//         file << scientific << node->getX() << " ";
+//         file << scientific << node->getY() << " ";
+//         file << scientific << node->getZ() << " ";
+// 
+//         tmp++;
+//     }
+//     /* Write DataArray end */
+//     file << endl << "</DataArray>" << endl;
+//     /* Write Points end*/
+//     file << "</Points>" << endl;
+// }
+// 
+// void OutputVTK::write_vtk_topology(void)
+// {
+//     Mesh *mesh = this->_mesh;
+//     ofstream &file = this->_data_file;
+// 
+//     Node* node;
+//     //ElementIter ele;
+//     unsigned int li;
+//     int tmp;
+// 
+//     /* Write Cells begin*/
+//     file << "<Cells>" << endl;
+//     /* Write DataArray begin */
+//     file << "<DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">" << endl;
+//     /* Write own coordinates */
+//     FOR_ELEMENTS(mesh, ele) {
+//         FOR_ELEMENT_NODES(ele, li) {
+//             node = ele->node[li];
+//             file << node->aux << " ";   /* Write connectivity */
+//         }
+//     }
+//     /* Write DataArray end */
+//     file << endl << "</DataArray>" << endl;
+// 
+//     /* Write DataArray begin */
+//     file << "<DataArray type=\"Int32\" Name=\"offsets\" format=\"ascii\">" << endl;
+//     /* Write number of nodes for each element */
+//     tmp = 0;
+//     FOR_ELEMENTS(mesh, ele) {
+//         switch(ele->dim()) {
+//         case 1:
+//             tmp += VTK_LINE_SIZE;
+//             break;
+//         case 2:
+//             tmp += VTK_TRIANGLE_SIZE;
+//             break;
+//         case 3:
+//             tmp += VTK_TETRA_SIZE;
+//             break;
+//         }
+//         file << tmp << " ";
+//     }
+//     /* Write DataArray end */
+//     file << endl << "</DataArray>" << endl;
+// 
+//     /* Write DataArray begin */
+//     file << "<DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">" << endl;
+//     /* Write type of nodes for each element */
+//     FOR_ELEMENTS(mesh, ele) {
+//         switch(ele->dim()) {
+//         case 1:
+//             file << (int)VTK_LINE << " ";
+//             break;
+//         case 2:
+//             file << (int)VTK_TRIANGLE << " ";
+//             break;
+//         case 3:
+//             file << (int)VTK_TETRA << " ";
+//             break;
+//         }
+//     }
+//     /* Write DataArray end */
+//     file << endl << "</DataArray>" << endl;
+// 
+//     /* Write Cells end*/
+//     file << "</Cells>" << endl;
+// }

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -40,6 +40,27 @@ OutputElementIterator OutputMesh::end()
     return OutputElementIterator(OutputElement(offsets_->n_values, this));
 }
 
+unsigned int OutputMesh::n_elements()
+{
+    return offsets_->n_values;
+}
+
+unsigned int OutputMesh::n_nodes()
+{
+    return nodes_->n_values;
+}
+
+unsigned int OutputMesh::n_nodes_disc()
+{
+    //ASSERT_DBG(output_mesh_->discont_data_computed_);
+    if(discont_data_computed_)
+        return discont_nodes_->n_values;
+    else
+        return 0;
+}
+
+
+
 void OutputMesh::create_identical_mesh()
 {
 //     DBGMSG("create identical outputmesh\n");

--- a/src/io/output_mesh.cc
+++ b/src/io/output_mesh.cc
@@ -169,53 +169,6 @@ void OutputMesh::compute_discontinuous_data()
 void OutputMesh::create_refined_mesh(Field<3, FieldValue<3>::Scalar> *error_control_field)
 {
     ASSERT(0).error("Not implemented yet.");
-    
-    orig_element_indices_ = std::make_shared<std::vector<unsigned int>>();
-    local_nodes_ = std::make_shared<std::vector<double>>();
-    
-    //FIXME: suggest required capacity
-    unsigned int capacity = 16*orig_mesh_->n_elements();
-    orig_element_indices_->reserve(capacity);
-    local_nodes_->reserve(3*capacity);
-    
-    // create node indices for connectivity
-    unsigned int node_id = 0;   // node id
-    FOR_NODES(orig_mesh_, node) {
-        node->aux = node_id;   // store node index in the auxiliary variable
-        node_id++;
-    }
-    
-    FOR_ELEMENTS(orig_mesh_, ele) {
-        arma::vec3 centre = ele->centre();
-        
-        AuxElement aux_ele;
-        aux_ele.connectivity.resize(ele->n_nodes());
-        aux_ele.coords.resize(ele->n_nodes()*3);
-        for(unsigned int i=0; i<ele->n_nodes(); i++)
-        {
-            Node* node = ele->node[i];
-            aux_ele.connectivity[i] = node->aux;
-            aux_ele.coords[i] = node->getX();
-            aux_ele.coords[i+1] = node->getY();
-            aux_ele.coords[i+2] = node->getZ();
-        }
-        
-        //refinement refinement
-        // if(refinement_criterion())
-        {
-            // new element:
-            // centre + combination of dim nodes from all nodes
-            static const std::vector<std::vector<std::vector<unsigned int>>> side_permutations = 
-                {   { {0},{1}}, // line
-                    { {0,1}, {0,2}, {1,2}}, //triangle
-                    { {0,1,2}, {0,1,3}, {0,2,3}, {1,2,3}}   //tetrahedron
-                };
-            
-        }
-    }
-    
-    orig_element_indices_->shrink_to_fit();
-    local_nodes_->shrink_to_fit();
 }
 
 

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -15,6 +15,9 @@
  * @brief   Classes for auxiliary output mesh.
  */
 
+#ifndef OUTPUT_MESH_HH_
+#define OUTPUT_MESH_HH_
+
 #include <string>
 
 #include "system/sys_profiler.hh"
@@ -23,8 +26,12 @@
 #include "io/output_data_base.hh"
 
 #include "fields/field_values.hh"
+
+
+
 class Mesh;
 template<int, class Value> class Field;
+class OutputElementIterator;
 
 /// Class representing data vector of geometry and topology information (especially for VTK).
 /// Filling the vector is the users responsibility.
@@ -53,6 +60,11 @@ public:
             out_stream << d << " ";
     }
     
+    T& operator[](unsigned int i){
+        ASSERT(i < data_.size());
+        return data_[i];
+    }
+    
     /// Data vector.
     std::vector<T> data_;
 };
@@ -67,6 +79,9 @@ public:
     
     void create_identical_mesh();
     void create_refined_mesh(Field<3, FieldValue<3>::Scalar> *error_control_field);
+    
+    OutputElementIterator begin();
+    OutputElementIterator end();
     
     std::shared_ptr<std::vector<unsigned int>> orig_element_indices_;
     std::shared_ptr<std::vector<double>> local_nodes_;
@@ -93,7 +108,10 @@ private:
     bool discont_data_computed_;
     
     const unsigned int max_level = 2;
+    
+    friend class OutputElement;
 };
 
 
+#endif  // OUTPUT_MESH_HH_
 

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -22,7 +22,9 @@
 
 #include "io/output_data_base.hh"
 
+#include "fields/field_values.hh"
 class Mesh;
+template<int, class Value> class Field;
 
 /// Class representing data vector of geometry and topology information (especially for VTK).
 /// Filling the vector is the users responsibility.
@@ -60,8 +62,14 @@ public:
 class OutputMesh
 {
 public:
-    OutputMesh(Mesh *mesh);
+    OutputMesh(Mesh* mesh);
     ~OutputMesh();
+    
+    void create_identical_mesh();
+    void create_refined_mesh(Field<3, FieldValue<3>::Scalar> *error_control_field);
+    
+    std::shared_ptr<std::vector<unsigned int>> orig_element_indices_;
+    std::shared_ptr<std::vector<double>> local_nodes_;
     
     std::shared_ptr<MeshData<double>> nodes_;
     std::shared_ptr<MeshData<unsigned int>> connectivity_;
@@ -70,8 +78,22 @@ public:
     void compute_discontinuous_data();
     std::shared_ptr<MeshData<double>> discont_nodes_;
     std::shared_ptr<MeshData<unsigned int>> discont_connectivity_;
+    
 private:
+    
+    struct AuxElement{
+        std::vector<double> coords;
+        std::vector<unsigned int> connectivity;
+    };
+    
     void fill_vectors();
-    bool discont_data_computed_;
+    bool refinement_criterion();
+    
     Mesh *orig_mesh_;
+    bool discont_data_computed_;
+    
+    const unsigned int max_level = 2;
 };
+
+
+

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -74,6 +74,8 @@ public:
 class OutputMesh
 {
 public:
+    static const unsigned int spacedim = 3;
+    
     OutputMesh(Mesh* mesh);
     ~OutputMesh();
     

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -88,7 +88,6 @@ public:
     OutputElementIterator end();
     
     std::shared_ptr<std::vector<unsigned int>> orig_element_indices_;
-    std::shared_ptr<std::vector<double>> local_nodes_;
     
     std::shared_ptr<MeshData<double>> nodes_;
     std::shared_ptr<MeshData<unsigned int>> connectivity_;
@@ -108,7 +107,6 @@ private:
     bool refinement_criterion();
     
     Mesh *orig_mesh_;
-    bool discont_data_computed_;
     
     const unsigned int max_level = 2;
     

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -1,0 +1,72 @@
+/*!
+ *
+﻿ * Copyright (C) 2015 Technical University of Liberec.  All rights reserved.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3 as published by the
+ * Free Software Foundation. (http://www.gnu.org/licenses/gpl-3.0.en.html)
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * 
+ * @file    output_mesh.hh
+ * @brief   Classes for auxiliary output mesh.
+ */
+
+#include <string>
+
+#include "system/sys_profiler.hh"
+#include "input/accessors.hh"
+
+#include "io/output_data_base.hh"
+
+class Mesh;
+
+/// Class representing data vector of geometry and topology information (especially for VTK).
+/// Filling the vector is the users responsibility.
+template <typename T>
+class MeshData : public OutputDataBase {
+public:
+    /// Constructor. @p name is the possible name of the output vector.
+    MeshData(std::string name, NumCompValueType n_elem = N_SCALAR)
+    {
+        output_field_name = name;
+        n_elem_ = n_elem;
+    }
+    
+    ~MeshData() override 
+    {};
+    
+    /// Prints @p idx element of data vector into stream.
+    void print(std::ostream& out_stream, unsigned int idx) override {
+        ASSERT_LE(idx, this->n_values);
+        out_stream << data_[idx] ;
+    }
+    
+    /// Prints the whole data vector into stream.
+    void print_all(std::ostream& out_stream) override {
+        for(auto &d : data_)
+            out_stream << d << " ";
+    }
+    
+    /// Data vector.
+    std::vector<T> data_;
+};
+
+
+
+class OutputMesh
+{
+public:
+    OutputMesh(Mesh *mesh);
+    ~OutputMesh();
+    
+    std::shared_ptr<MeshData<double>> nodes_;
+    std::shared_ptr<MeshData<unsigned int>> connectivity_;
+    std::shared_ptr<MeshData<unsigned int>> offsets_;
+    
+private:
+    void fill_vectors(Mesh *mesh);
+};

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -27,11 +27,13 @@
 
 #include "fields/field_values.hh"
 
-
+#include "tools/general_iterator.hh"
 
 class Mesh;
 template<int, class Value> class Field;
-class OutputElementIterator;
+
+class OutputElement;
+typedef GeneralIterator<OutputElement> OutputElementIterator;
 
 /// Class representing data vector of geometry and topology information (especially for VTK).
 /// Filling the vector is the users responsibility.

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -104,11 +104,6 @@ public:
     
 private:
     
-    struct AuxElement{
-        std::vector<double> coords;
-        std::vector<unsigned int> connectivity;
-    };
-    
     void fill_vectors();
     bool refinement_criterion();
     

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -94,6 +94,10 @@ public:
     std::shared_ptr<MeshData<double>> discont_nodes_;
     std::shared_ptr<MeshData<unsigned int>> discont_connectivity_;
     
+    unsigned int n_nodes();
+    unsigned int n_nodes_disc();
+    unsigned int n_elements();
+    
 private:
     
     struct AuxElement{

--- a/src/io/output_mesh.hh
+++ b/src/io/output_mesh.hh
@@ -67,6 +67,11 @@ public:
     std::shared_ptr<MeshData<unsigned int>> connectivity_;
     std::shared_ptr<MeshData<unsigned int>> offsets_;
     
+    void compute_discontinuous_data();
+    std::shared_ptr<MeshData<double>> discont_nodes_;
+    std::shared_ptr<MeshData<unsigned int>> discont_connectivity_;
 private:
-    void fill_vectors(Mesh *mesh);
+    void fill_vectors();
+    bool discont_data_computed_;
+    Mesh *orig_mesh_;
 };

--- a/src/io/output_msh.cc
+++ b/src/io/output_msh.cc
@@ -248,16 +248,9 @@ int OutputMSH::write_tail(void)
 
 OutputMSH::OutputMSH(const Input::Record &in_rec) : OutputTime(in_rec)
 {
+    this->enable_refinement_ = false;
 	this->fix_main_file_extension(".msh");
     this->header_written = false;
-
-    // skip creation of output mesh (use computational one)
-    if( ! this->error_control_field_name.empty())
-    {
-        xprintf(Warn,"Ignoring error_control_field ('%s').\n Output in GMSH format available only on computational mesh!\n",
-                this->error_control_field_name.c_str() );
-        this->error_control_field_name = "";
-    }
     
     if(this->rank == 0) {
         this->_base_file.open(this->_base_filename.c_str());

--- a/src/io/output_msh.cc
+++ b/src/io/output_msh.cc
@@ -251,6 +251,14 @@ OutputMSH::OutputMSH(const Input::Record &in_rec) : OutputTime(in_rec)
 	this->fix_main_file_extension(".msh");
     this->header_written = false;
 
+    // skip creation of output mesh (use computational one)
+    if( ! this->error_control_field_name.empty())
+    {
+        xprintf(Warn,"Ignoring error_control_field ('%s').\n Output in GMSH format available only on computational mesh!\n",
+                this->error_control_field_name.c_str() );
+        this->error_control_field_name = "";
+    }
+    
     if(this->rank == 0) {
         this->_base_file.open(this->_base_filename.c_str());
         INPUT_CHECK( this->_base_file.is_open() , "Can not open output file: %s\n", this->_base_filename.c_str() );

--- a/src/io/output_time.cc
+++ b/src/io/output_time.cc
@@ -68,16 +68,16 @@ OutputTime::OutputTime()
 
 
 OutputTime::OutputTime(const Input::Record &in_rec)
-: input_record_(in_rec), 
+: current_step(0),
+    time(-1.0),
+    write_time(-1.0),
+    input_record_(in_rec),
     _mesh(nullptr), 
     output_mesh_(nullptr),
     is_output_mesh_valid_(false)
 {
-
+    // Read output base file name
     this->_base_filename = in_rec.val<FilePath>("file");
-    this->current_step = 0;
-    this->time = -1.0;
-    this->write_time = -1.0;
     
     // Read optional error control field name for output mesh generation
     auto it = in_rec.find<std::string>("error_control_field");
@@ -132,12 +132,13 @@ void OutputTime::make_output_mesh(Mesh* mesh, FieldSet* output_fields)
     
     // set validity of the output mesh for the current writing time
     is_output_mesh_valid_ = true;
+    _mesh = mesh;
 }
 
 
 void OutputTime::compute_discontinuous_output_mesh()
 {
-    ASSERT(output_mesh_).error("Create output mesh first!");
+    ASSERT_PTR(output_mesh_).error("Create output mesh first!");
     output_mesh_->compute_discontinuous_data();
 }
 

--- a/src/io/output_time.cc
+++ b/src/io/output_time.cc
@@ -23,6 +23,7 @@
 #include "output_time.impl.hh"
 #include "output_vtk.hh"
 #include "output_msh.hh"
+#include "output_mesh.hh"
 
 
 FLOW123D_FORCE_LINK_IN_PARENT(vtk)
@@ -59,18 +60,17 @@ Abstract & OutputTime::get_input_format_type() {
 
 
 OutputTime::OutputTime()
-: _mesh(nullptr)
+: _mesh(nullptr), output_mesh_(nullptr)
 {}
 
 
 
 OutputTime::OutputTime(const Input::Record &in_rec)
-: input_record_(in_rec)
+: input_record_(in_rec), _mesh(nullptr), output_mesh_(nullptr)
 {
 
     this->_base_filename = in_rec.val<FilePath>("file");
     this->current_step = 0;
-    this->_mesh = NULL;
     this->time = -1.0;
     this->write_time = -1.0;
 
@@ -91,12 +91,16 @@ OutputTime::~OutputTime(void)
 
     if (this->_base_file.is_open()) this->_base_file.close();
 
-     xprintf(MsgLog, "O.K.\n");
+    if(output_mesh_ != nullptr) delete output_mesh_;
+    xprintf(MsgLog, "O.K.\n");
 }
 
 
 
-
+void OutputTime::make_output_mesh(Mesh* mesh)
+{
+    output_mesh_ = new OutputMesh(mesh);
+}
 
 
 

--- a/src/io/output_time.cc
+++ b/src/io/output_time.cc
@@ -62,7 +62,7 @@ Abstract & OutputTime::get_input_format_type() {
 
 
 OutputTime::OutputTime()
-: _mesh(nullptr), output_mesh_(nullptr)
+: _mesh(nullptr)
 {}
 
 
@@ -73,7 +73,6 @@ OutputTime::OutputTime(const Input::Record &in_rec)
     write_time(-1.0),
     input_record_(in_rec),
     _mesh(nullptr), 
-    output_mesh_(nullptr),
     is_output_mesh_valid_(false)
 {
     // Read output base file name
@@ -102,7 +101,6 @@ OutputTime::~OutputTime(void)
 
     if (this->_base_file.is_open()) this->_base_file.close();
 
-    if(output_mesh_ != nullptr) delete output_mesh_;
     xprintf(MsgLog, "O.K.\n");
 }
 
@@ -113,9 +111,8 @@ void OutputTime::make_output_mesh(Mesh* mesh, FieldSet* output_fields)
     if(is_output_mesh_valid_) return;
     
     // possibly destroy previous output mesh
-    if(output_mesh_) delete output_mesh_;
-    
-    output_mesh_ = new OutputMesh(mesh);
+//     if(output_mesh_) output_mesh_.reset();
+    output_mesh_ = std::make_shared<OutputMesh>(mesh);
     
     FieldCommon* field =  output_fields->field(error_control_field_name);
     if( field && (typeid(*field) == typeid(Field<3,FieldValue<3>::Scalar>)) ) {

--- a/src/io/output_time.cc
+++ b/src/io/output_time.cc
@@ -113,6 +113,7 @@ void OutputTime::make_output_mesh(Mesh* mesh, FieldSet* output_fields)
     // possibly destroy previous output mesh
 //     if(output_mesh_) output_mesh_.reset();
     output_mesh_ = std::make_shared<OutputMesh>(mesh);
+    output_mesh_discont_ = std::make_shared<OutputMeshDiscontinuous>(mesh);
     
     FieldCommon* field =  output_fields->field(error_control_field_name);
     if( field && (typeid(*field) == typeid(Field<3,FieldValue<3>::Scalar>)) ) {
@@ -136,7 +137,7 @@ void OutputTime::make_output_mesh(Mesh* mesh, FieldSet* output_fields)
 void OutputTime::compute_discontinuous_output_mesh()
 {
     ASSERT_PTR(output_mesh_).error("Create output mesh first!");
-    output_mesh_->compute_discontinuous_data();
+    output_mesh_discont_->create_mesh(output_mesh_);
 }
 
 

--- a/src/io/output_time.cc
+++ b/src/io/output_time.cc
@@ -103,6 +103,13 @@ void OutputTime::make_output_mesh(Mesh* mesh)
 }
 
 
+void OutputTime::compute_discontinuous_output_mesh()
+{
+    ASSERT(output_mesh_).error("Create output mesh first!");
+    output_mesh_->compute_discontinuous_data();
+}
+
+
 
 void OutputTime::fix_main_file_extension(std::string extension)
 {

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -240,12 +240,11 @@ protected:
     
     /// Output mesh.
     std::shared_ptr<OutputMesh> output_mesh_;
+    /// Discontinuous (non-conforming) mesh. Used for CORNER_DATA.
     std::shared_ptr<OutputMeshDiscontinuous> output_mesh_discont_;
     
-    /** @brief Name of the output field according to which the output mesh is refined.
-     * When empty, the computational mesh is used for output.
-     */
-    std::string error_control_field_name;
+    /// Auxliary flag for refinement enabling, due to gmsh format.
+    bool enable_refinement_;
 };
 
 

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -28,6 +28,7 @@ class Mesh;
 class FieldCommon; // in fact not necessary, output_data_by_field() can use directly name as parameter
 template <int spacedim, class Value>
 class Field;
+class FieldSet;
 template <int spacedim, class Value>
 class MultiField;
 class TimeGovernor;
@@ -94,6 +95,8 @@ public:
      */
     static std::shared_ptr<OutputTime> create_output_stream(const Input::Record &in_rec);
     
+    void make_output_mesh(Mesh* mesh, FieldSet* output_fields);
+    
     /**
      * \brief Generic method for registering output data stored in MultiField
      *
@@ -154,8 +157,7 @@ public:
     Input::AbstractRecord format_record_;
 
 protected:
-
-    void make_output_mesh(Mesh* mesh);
+    
     void compute_discontinuous_output_mesh();
     
     /**
@@ -236,6 +238,17 @@ protected:
     Mesh *_mesh;
     
     OutputMesh *output_mesh_;
+    
+    /** @brief Flag is set true when output mesh for the current write time has been created.
+     * Guarantees output mesh creation only once per write time, 
+     * assuming all fields are written on the same output mesh.
+     */
+    bool is_output_mesh_valid_;
+    
+    /** @brief Name of the output field according to which the output mesh is refined.
+     * When empty, the computational mesh is used for output.
+     */
+    std::string error_control_field_name;
 };
 
 

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -31,6 +31,7 @@ class Field;
 template <int spacedim, class Value>
 class MultiField;
 class TimeGovernor;
+class OutputMesh;
 
 /**
  * \brief The class for outputting data during time.
@@ -92,7 +93,7 @@ public:
      * record in configuration file.
      */
     static std::shared_ptr<OutputTime> create_output_stream(const Input::Record &in_rec);
-
+    
     /**
      * \brief Generic method for registering output data stored in MultiField
      *
@@ -154,6 +155,8 @@ public:
 
 protected:
 
+    void make_output_mesh(Mesh* mesh);
+    
     /**
      * Interpolate given @p field into output discrete @p space and store the values
      * into private storage for postponed output.
@@ -230,6 +233,8 @@ protected:
      * Cached pointer at mesh used by this output stream
      */
     Mesh *_mesh;
+    
+    OutputMesh *output_mesh_;
 };
 
 

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -237,7 +237,8 @@ protected:
      */
     Mesh *_mesh;
     
-    OutputMesh *output_mesh_;
+    /// Output mesh.
+    std::shared_ptr<OutputMesh> output_mesh_;
     
     /** @brief Flag is set true when output mesh for the current write time has been created.
      * Guarantees output mesh creation only once per write time, 

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -33,6 +33,7 @@ template <int spacedim, class Value>
 class MultiField;
 class TimeGovernor;
 class OutputMesh;
+class OutputMeshDiscontinuous;
 
 /**
  * \brief The class for outputting data during time.
@@ -239,6 +240,7 @@ protected:
     
     /// Output mesh.
     std::shared_ptr<OutputMesh> output_mesh_;
+    std::shared_ptr<OutputMeshDiscontinuous> output_mesh_discont_;
     
     /** @brief Flag is set true when output mesh for the current write time has been created.
      * Guarantees output mesh creation only once per write time, 

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -242,12 +242,6 @@ protected:
     std::shared_ptr<OutputMesh> output_mesh_;
     std::shared_ptr<OutputMeshDiscontinuous> output_mesh_discont_;
     
-    /** @brief Flag is set true when output mesh for the current write time has been created.
-     * Guarantees output mesh creation only once per write time, 
-     * assuming all fields are written on the same output mesh.
-     */
-    bool is_output_mesh_valid_;
-    
     /** @brief Name of the output field according to which the output mesh is refined.
      * When empty, the computational mesh is used for output.
      */

--- a/src/io/output_time.hh
+++ b/src/io/output_time.hh
@@ -156,6 +156,7 @@ public:
 protected:
 
     void make_output_mesh(Mesh* mesh);
+    void compute_discontinuous_output_mesh();
     
     /**
      * Interpolate given @p field into output discrete @p space and store the values

--- a/src/io/output_time.impl.hh
+++ b/src/io/output_time.impl.hh
@@ -294,10 +294,6 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     this->_mesh=field_mesh;
     OLD_ASSERT(this->_mesh, "Null mesh pointer.\n");
 
-    DBGMSG("compute_field_data \n");
-    if(output_mesh_ == nullptr)
-        make_output_mesh(_mesh);
-    DBGMSG("compute_field_data\n");
     
     // get possibly existing data for the same field, check both name and type
     std::vector<unsigned int> size(N_DISCRETE_SPACES);

--- a/src/io/output_time.impl.hh
+++ b/src/io/output_time.impl.hh
@@ -319,16 +319,16 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
         for(unsigned int idx=0; idx < output_data.n_values; idx++)
             output_data.zero(idx);
 
-        for(OutputElementIterator it = output_mesh_->begin(); it != output_mesh_->end(); ++it)
+        for(const auto & ele : *output_mesh_)
         {
-            std::vector<Space<3>::Point> vertices = it->vertex_list();
-            for(unsigned int i=0; i < it->n_nodes(); i++)
+            std::vector<Space<3>::Point> vertices = ele.vertex_list();
+            for(unsigned int i=0; i < ele.n_nodes(); i++)
             {
-                unsigned int node_index = it->node_index(i);
+                unsigned int node_index = ele.node_index(i);
                 const Value &node_value =
                         Value( const_cast<typename Value::return_type &>(
                                 field.value(vertices[i],
-                                            ElementAccessor<spacedim>(it->orig_mesh(), it->orig_element_idx(),false) ))
+                                            ElementAccessor<spacedim>(ele.orig_mesh(), ele.orig_element_idx(),false) ))
                              );
                 output_data.add(node_index, node_value);
                 count[node_index]++;
@@ -342,16 +342,16 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     break;
     case CORNER_DATA: {
         DBGMSG("compute field CORNER data\n");
-        for(OutputElementIterator it = output_mesh_->begin(); it != output_mesh_->end(); ++it)
+        for(const auto & ele : *output_mesh_)
         {
-            std::vector<Space<3>::Point> vertices = it->vertex_list_disc();
-            for(unsigned int i=0; i < it->n_nodes(); i++)
+            std::vector<Space<3>::Point> vertices = ele.vertex_list_disc();
+            for(unsigned int i=0; i < ele.n_nodes(); i++)
             {
-                unsigned int node_index = it->node_index_disc(i);
+                unsigned int node_index = ele.node_index_disc(i);
                 const Value &node_value =
                         Value( const_cast<typename Value::return_type &>(
                                 field.value(vertices[i],
-                                            ElementAccessor<spacedim>(it->orig_mesh(), it->orig_element_idx(),false) ))
+                                            ElementAccessor<spacedim>(ele.orig_mesh(), ele.orig_element_idx(),false) ))
                              );
                 output_data.store_value(node_index,  node_value);
             }
@@ -360,13 +360,13 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     break;
     case ELEM_DATA: {
         DBGMSG("compute field ELEM data\n");
-        for(OutputElementIterator it = output_mesh_->begin(); it != output_mesh_->end(); ++it)
+        for(const auto & ele : *output_mesh_)
         {
-            unsigned int ele_index = it->idx();
+            unsigned int ele_index = ele.idx();
             const Value &ele_value =
                         Value( const_cast<typename Value::return_type &>(
-                                field.value(it->centre(),
-                                            ElementAccessor<spacedim>(it->orig_mesh(), it->orig_element_idx(),false))
+                                field.value(ele.centre(),
+                                            ElementAccessor<spacedim>(ele.orig_mesh(), ele.orig_element_idx(),false))
                                                                         )
                              );
                 output_data.store_value(ele_index,  ele_value);

--- a/src/io/output_time.impl.hh
+++ b/src/io/output_time.impl.hh
@@ -281,7 +281,6 @@ void OutputTime::register_data(const DiscreteSpace type,
 template<int spacedim, class Value>
 void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Value> &field)
 {
-
     /* It's possible now to do output to the file only in the first process */
     if( this->rank != 0) {
         /* TODO: do something, when support for Parallel VTK is added */
@@ -295,6 +294,11 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     this->_mesh=field_mesh;
     OLD_ASSERT(this->_mesh, "Null mesh pointer.\n");
 
+    DBGMSG("compute_field_data \n");
+    if(output_mesh_ == nullptr)
+        make_output_mesh(_mesh);
+    DBGMSG("compute_field_data\n");
+    
     // get possibly existing data for the same field, check both name and type
     std::vector<unsigned int> size(N_DISCRETE_SPACES);
     size[NODE_DATA]=this->_mesh->n_nodes();

--- a/src/io/output_time.impl.hh
+++ b/src/io/output_time.impl.hh
@@ -347,6 +347,7 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     }
     break;
     case CORNER_DATA: {
+        compute_discontinuous_output_mesh();
         unsigned int corner_index=0;
         FOR_ELEMENTS(this->_mesh, ele) {
             FOR_ELEMENT_NODES(ele, i_node) {

--- a/src/io/output_time.impl.hh
+++ b/src/io/output_time.impl.hh
@@ -298,7 +298,7 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     std::vector<unsigned int> size(N_DISCRETE_SPACES);
     size[NODE_DATA] = output_mesh_->n_nodes();
     size[ELEM_DATA] = output_mesh_->n_elements();
-    size[CORNER_DATA] = output_mesh_->n_nodes_disc();
+    size[CORNER_DATA] = output_mesh_discont_->n_nodes();
 
     auto &od_vec=this->output_data_vec_[space_type];
     auto it=std::find_if(od_vec.begin(), od_vec.end(),
@@ -342,12 +342,12 @@ void OutputTime::compute_field_data(DiscreteSpace space_type, Field<spacedim, Va
     break;
     case CORNER_DATA: {
         DBGMSG("compute field CORNER data\n");
-        for(const auto & ele : *output_mesh_)
+        for(const auto & ele : *output_mesh_discont_)
         {
-            std::vector<Space<3>::Point> vertices = ele.vertex_list_disc();
+            std::vector<Space<3>::Point> vertices = ele.vertex_list();
             for(unsigned int i=0; i < ele.n_nodes(); i++)
             {
-                unsigned int node_index = ele.node_index_disc(i);
+                unsigned int node_index = ele.node_index(i);
                 const Value &node_value =
                         Value( const_cast<typename Value::return_type &>(
                                 field.value(vertices[i],

--- a/src/io/output_vtk.cc
+++ b/src/io/output_vtk.cc
@@ -70,6 +70,7 @@ const int OutputVTK::registrar = Input::register_class< OutputVTK, const Input::
 
 OutputVTK::OutputVTK(const Input::Record &in_rec) : OutputTime(in_rec)
 {
+    this->enable_refinement_ = true;
     this->fix_main_file_extension(".pvd");
 
     if(this->rank == 0) {

--- a/src/io/output_vtk.cc
+++ b/src/io/output_vtk.cc
@@ -183,103 +183,7 @@ void OutputVTK::write_vtk_vtu_head(void)
     file << "<UnstructuredGrid>" << endl;
 }
 
-// void OutputVTK::write_vtk_geometry(void)
-// {
-//     Mesh *mesh = this->_mesh;
-//     ofstream &file = this->_data_file;
-// 
-//     int tmp;
-// 
-//     /* Write Points begin*/
-//     file << "<Points>" << endl;
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">" << endl;
-//     /* Write own coordinates */
-//     tmp = 0;
-//     /* Set floating point precision */
-//     file.precision(std::numeric_limits<double>::digits10);
-//     FOR_NODES(mesh, node) {
-//         node->aux = tmp;   /* store index in the auxiliary variable */
-// 
-//         file << scientific << node->getX() << " ";
-//         file << scientific << node->getY() << " ";
-//         file << scientific << node->getZ() << " ";
-// 
-//         tmp++;
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-//     /* Write Points end*/
-//     file << "</Points>" << endl;
-// }
 
-// void OutputVTK::write_vtk_topology(void)
-// {
-//     Mesh *mesh = this->_mesh;
-//     ofstream &file = this->_data_file;
-// 
-//     Node* node;
-//     //ElementIter ele;
-//     unsigned int li;
-//     int tmp;
-// 
-//     /* Write Cells begin*/
-//     file << "<Cells>" << endl;
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">" << endl;
-//     /* Write own coordinates */
-//     FOR_ELEMENTS(mesh, ele) {
-//         FOR_ELEMENT_NODES(ele, li) {
-//             node = ele->node[li];
-//             file << node->aux << " ";   /* Write connectivity */
-//         }
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-// 
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"Int32\" Name=\"offsets\" format=\"ascii\">" << endl;
-//     /* Write number of nodes for each element */
-//     tmp = 0;
-//     FOR_ELEMENTS(mesh, ele) {
-//         switch(ele->dim()) {
-//         case 1:
-//             tmp += VTK_LINE_SIZE;
-//             break;
-//         case 2:
-//             tmp += VTK_TRIANGLE_SIZE;
-//             break;
-//         case 3:
-//             tmp += VTK_TETRA_SIZE;
-//             break;
-//         }
-//         file << tmp << " ";
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-// 
-//     /* Write DataArray begin */
-//     file << "<DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">" << endl;
-//     /* Write type of nodes for each element */
-//     FOR_ELEMENTS(mesh, ele) {
-//         switch(ele->dim()) {
-//         case 1:
-//             file << (int)VTK_LINE << " ";
-//             break;
-//         case 2:
-//             file << (int)VTK_TRIANGLE << " ";
-//             break;
-//         case 3:
-//             file << (int)VTK_TETRA << " ";
-//             break;
-//         }
-//     }
-//     /* Write DataArray end */
-//     file << endl << "</DataArray>" << endl;
-// 
-//     /* Write Cells end*/
-//     file << "</Cells>" << endl;
-// }
 
 void OutputVTK::fill_element_types_vector(std::vector< unsigned int >& data)
 {    
@@ -320,111 +224,16 @@ void OutputVTK::fill_element_types_vector(std::vector< unsigned int >& data)
 }
 
 
-void OutputVTK::write_vtk_discont_geometry(void)
-{
-    Mesh *mesh = this->_mesh;
-    ofstream &file = this->_data_file;
-
-    NodeIter node;
-    unsigned int li;
-
-    /* Write Points begin*/
-    file << "<Points>" << endl;
-    /* Write DataArray begin */
-    file << "<DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">" << endl;
-    /* Set floating point precision */
-    file.precision(std::numeric_limits<double>::digits10);
-    FOR_ELEMENTS(mesh, ele) {
-        FOR_ELEMENT_NODES(ele, li) {
-            node = ele->node[li];
-
-            file << scientific << node->getX() << " ";
-            file << scientific << node->getY() << " ";
-            file << scientific << node->getZ() << " ";
-        }
-    }
-    /* Write DataArray end */
-    file << endl << "</DataArray>" << endl;
-    /* Write Points end*/
-    file << "</Points>" << endl;
-}
-
-void OutputVTK::write_vtk_discont_topology(void)
-{
-    Mesh *mesh = this->_mesh;
-    ofstream &file = this->_data_file;
-
-    //Node* node;
-    //ElementIter ele;
-    unsigned int li, tmp;
-
-    /* Write Cells begin*/
-    file << "<Cells>" << endl;
-    /* Write DataArray begin */
-    file << "<DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">" << endl;
-    /* Write own coordinates */
-    tmp = 0;
-    FOR_ELEMENTS(mesh, ele) {
-        FOR_ELEMENT_NODES(ele, li) {
-            file << tmp << " ";   /* Write connectivity */
-            tmp++;
-        }
-    }
-    /* Write DataArray end */
-    file << endl << "</DataArray>" << endl;
-
-    /* Write DataArray begin */
-    file << "<DataArray type=\"Int32\" Name=\"offsets\" format=\"ascii\">" << endl;
-    /* Write number of nodes for each element */
-    tmp = 0;
-    FOR_ELEMENTS(mesh, ele) {
-        switch(ele->dim()) {
-        case 1:
-            tmp += VTK_LINE_SIZE;
-            break;
-        case 2:
-            tmp += VTK_TRIANGLE_SIZE;
-            break;
-        case 3:
-            tmp += VTK_TETRA_SIZE;
-            break;
-        }
-        file << tmp << " ";
-    }
-    /* Write DataArray end */
-    file << endl << "</DataArray>" << endl;
-
-    /* Write DataArray begin */
-    file << "<DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">" << endl;
-    /* Write type of nodes for each element */
-    FOR_ELEMENTS(mesh, ele) {
-        switch(ele->dim()) {
-        case 1:
-            file << (int)VTK_LINE << " ";
-            break;
-        case 2:
-            file << (int)VTK_TRIANGLE << " ";
-            break;
-        case 3:
-            file << (int)VTK_TETRA << " ";
-            break;
-        }
-    }
-    /* Write DataArray end */
-    file << endl << "</DataArray>" << endl;
-
-    /* Write Cells end*/
-    file << "</Cells>" << endl;
-}
-
-
 
 void OutputVTK::write_vtk_data_ascii(OutputTime::OutputDataPtr output_data, VTKValueType type)
 {
     ofstream &file = this->_data_file;
 
-    file    << "<DataArray type=\"" << vtk_value_type_map(type) << "\" "
-            << "Name=\"" << output_data->output_field_name <<"\" ";
+    file    << "<DataArray type=\"" << vtk_value_type_map(type) << "\" ";
+    // possibly write name
+    if( ! output_data->output_field_name.empty()) 
+        file << "Name=\"" << output_data->output_field_name <<"\" ";
+    // write number of components
     if (output_data->n_elem_ > 1)
     {
         file
@@ -445,27 +254,8 @@ void OutputVTK::write_vtk_data_ascii(OutputTime::OutputDataPtr output_data, VTKV
 
 void OutputVTK::write_vtk_data_ascii(OutputDataFieldVec &output_data_vec)
 {
-    ofstream &file = this->_data_file;
-
     for(OutputDataPtr data :  output_data_vec)
-    {
-        file 	<< "<DataArray type=\"Float64\" "
-        		<< "Name=\"" << data->output_field_name <<"\" ";
-        if (data->n_elem_ > 1)
-        {
-        	file
-        		<< "NumberOfComponents=\"" << data->n_elem_ << "\" ";
-        }
-        file	<< "format=\"ascii\">"
-                << endl;
-
-        /* Set precision to max */
-        file.precision(std::numeric_limits<double>::digits10);
-
-        data->print_all(file);
-
-        file << "\n</DataArray>" << endl;
-    }
+        write_vtk_data_ascii(data, VTK_FLOAT64);
 }
 
 
@@ -563,7 +353,6 @@ void OutputVTK::write_vtk_vtu(void)
         /* Write Piece begin */
         file << "<Piece NumberOfPoints=\"" << mesh->n_nodes() << "\" NumberOfCells=\"" << mesh->n_elements() <<"\">" << endl;
 
-        DBGMSG("new write\n");
         /* Write VTK Geometry */
         file << "<Points>" << endl;
             write_vtk_data_ascii(output_mesh_->nodes_, VTK_FLOAT64 );
@@ -571,7 +360,6 @@ void OutputVTK::write_vtk_vtu(void)
     
         
         /* Write VTK Topology */
-//         this->write_vtk_topology();
         file << "<Cells>" << endl;
             write_vtk_data_ascii(output_mesh_->connectivity_, VTK_INT32 );
             write_vtk_data_ascii(output_mesh_->offsets_, VTK_INT32 );
@@ -594,10 +382,18 @@ void OutputVTK::write_vtk_vtu(void)
         file << "<Piece NumberOfPoints=\"" << mesh->n_corners() << "\" NumberOfCells=\"" << mesh->n_elements() <<"\">" << endl;
 
         /* Write VTK Geometry */
-        this->write_vtk_discont_geometry();
+        file << "<Points>" << endl;
+            write_vtk_data_ascii(output_mesh_->discont_nodes_, VTK_FLOAT64 );
+        file << "</Points>" << endl;
 
         /* Write VTK Topology */
-        this->write_vtk_discont_topology();
+        file << "<Cells>" << endl;
+            write_vtk_data_ascii(output_mesh_->discont_connectivity_, VTK_INT32 );
+            write_vtk_data_ascii(output_mesh_->offsets_, VTK_INT32 );
+            auto types = std::make_shared<MeshData<unsigned int>>("types");
+            fill_element_types_vector(types->data_);
+            write_vtk_data_ascii(types, VTK_UINT8 );
+        file << "</Cells>" << endl;
 
         /* Write VTK scalar and vector data on nodes to the file */
         this->write_vtk_node_data();

--- a/src/io/output_vtk.cc
+++ b/src/io/output_vtk.cc
@@ -16,12 +16,12 @@
  */
 
 #include "output_vtk.hh"
-#include <limits.h>
-#include "mesh/mesh.h"
 #include "output_data_base.hh"
+#include "output_mesh.hh"
+
+#include <limits.h>
 #include "input/factory.hh"
 #include "input/accessors_forward.hh"
-#include "output_mesh.hh"
 
 FLOW123D_FORCE_LINK_IN_CHILD(vtk)
 
@@ -99,7 +99,7 @@ OutputVTK::~OutputVTK()
 
 int OutputVTK::write_data(void)
 {
-	OLD_ASSERT(_mesh != nullptr, "Null mesh.\n");
+    ASSERT_PTR(output_mesh_);
 
     /* It's possible now to do output to the file only in the first process */
     if(this->rank != 0) {
@@ -342,7 +342,6 @@ void OutputVTK::write_vtk_vtu_tail(void)
 void OutputVTK::write_vtk_vtu(void)
 {
     ofstream &file = this->_data_file;
-    Mesh *mesh = this->_mesh;
 
     /* Write header */
     this->write_vtk_vtu_head();
@@ -351,7 +350,8 @@ void OutputVTK::write_vtk_vtu(void)
     if ( this->output_data_vec_[CORNER_DATA].empty() )
     {
         /* Write Piece begin */
-        file << "<Piece NumberOfPoints=\"" << mesh->n_nodes() << "\" NumberOfCells=\"" << mesh->n_elements() <<"\">" << endl;
+        file << "<Piece NumberOfPoints=\"" << output_mesh_->n_nodes()
+                  << "\" NumberOfCells=\"" << output_mesh_->n_elements() <<"\">" << endl;
 
         /* Write VTK Geometry */
         file << "<Points>" << endl;
@@ -379,7 +379,8 @@ void OutputVTK::write_vtk_vtu(void)
 
     } else {
         /* Write Piece begin */
-        file << "<Piece NumberOfPoints=\"" << mesh->n_corners() << "\" NumberOfCells=\"" << mesh->n_elements() <<"\">" << endl;
+        file << "<Piece NumberOfPoints=\"" << output_mesh_->n_nodes_disc()
+                  << "\" NumberOfCells=\"" << output_mesh_->n_elements() <<"\">" << endl;
 
         /* Write VTK Geometry */
         file << "<Points>" << endl;

--- a/src/io/output_vtk.cc
+++ b/src/io/output_vtk.cc
@@ -379,18 +379,18 @@ void OutputVTK::write_vtk_vtu(void)
 
     } else {
         /* Write Piece begin */
-        file << "<Piece NumberOfPoints=\"" << output_mesh_->n_nodes_disc()
+        file << "<Piece NumberOfPoints=\"" << output_mesh_discont_->n_nodes()
                   << "\" NumberOfCells=\"" << output_mesh_->n_elements() <<"\">" << endl;
 
         /* Write VTK Geometry */
         file << "<Points>" << endl;
-            write_vtk_data_ascii(output_mesh_->discont_nodes_, VTK_FLOAT64 );
+            write_vtk_data_ascii(output_mesh_discont_->nodes_, VTK_FLOAT64 );
         file << "</Points>" << endl;
 
         /* Write VTK Topology */
         file << "<Cells>" << endl;
-            write_vtk_data_ascii(output_mesh_->discont_connectivity_, VTK_INT32 );
-            write_vtk_data_ascii(output_mesh_->offsets_, VTK_INT32 );
+            write_vtk_data_ascii(output_mesh_discont_->connectivity_, VTK_INT32 );
+            write_vtk_data_ascii(output_mesh_discont_->offsets_, VTK_INT32 );
             auto types = std::make_shared<MeshData<unsigned int>>("types");
             fill_element_types_vector(types->data_);
             write_vtk_data_ascii(types, VTK_UINT8 );

--- a/src/io/output_vtk.hh
+++ b/src/io/output_vtk.hh
@@ -132,6 +132,17 @@ protected:
         VTK_TETRA_SIZE = 4
     } VTKElemSize;
 
+    typedef enum { VTK_INT8, VTK_UINT8, VTK_INT16, VTK_UINT16, VTK_INT32, VTK_UINT32, 
+                   VTK_FLOAT32, VTK_FLOAT64
+    } VTKValueType;
+
+    static const std::string vtk_value_type_map(VTKValueType t) {
+        static const std::vector<std::string> types = {
+            "Int8", "UInt8", "Int16", "UInt16", "Int32", "UInt32",
+            "Float32","Float64"};
+        return types[t];
+    };
+
     /// Registrar of class to factory
     static const int registrar;
 
@@ -143,12 +154,13 @@ protected:
     /**
      * \brief Write geometry (position of nodes) to the VTK file (.vtu)
      */
-    void write_vtk_geometry(void);
+//     void write_vtk_geometry(void);
 
     /**
      * \brief Write topology (connection of nodes) to the VTK file (.vtu)
      */
-    void write_vtk_topology(void);
+//     void write_vtk_topology(void);
+    void fill_element_types_vector(std::vector<unsigned int> &data);
 
     /**
      * \brief Write geometry (position of nodes) to the VTK file (.vtu)
@@ -169,6 +181,11 @@ protected:
      */
     void write_vtk_data_ascii(OutputDataFieldVec &output_data_map);
 
+    /**
+     * Write registered data to output stream using ascii format
+     */
+    void write_vtk_data_ascii(OutputDataPtr output_data, VTKValueType type);
+    
     /**
      * \brief Write names of data sets in @p output_data vector that have value type equal to @p type.
      * Output is done into stream @p file.

--- a/src/io/output_vtk.hh
+++ b/src/io/output_vtk.hh
@@ -152,29 +152,9 @@ protected:
     void write_vtk_vtu_head(void);
 
     /**
-     * \brief Write geometry (position of nodes) to the VTK file (.vtu)
+     * \brief Fills the given vector with VTK element types indicators.
      */
-//     void write_vtk_geometry(void);
-
-    /**
-     * \brief Write topology (connection of nodes) to the VTK file (.vtu)
-     */
-//     void write_vtk_topology(void);
     void fill_element_types_vector(std::vector<unsigned int> &data);
-
-    /**
-     * \brief Write geometry (position of nodes) to the VTK file (.vtu)
-     *
-     * This method is used, when discontinuous data are saved to the .vtu file
-     */
-    void write_vtk_discont_geometry(void);
-
-    /**
-     * \brief Write topology (connection of nodes) to the VTK file (.vtu)
-     *
-     * This method is used, when discontinuous data are saved to the .vtu file
-     */
-    void write_vtk_discont_topology(void);
 
     /**
      * Write registered data to output stream using ascii format

--- a/src/tools/general_iterator.hh
+++ b/src/tools/general_iterator.hh
@@ -1,0 +1,97 @@
+// --------------------------------------------------- GeneralIterator ---------------------------------
+/*!
+ *
+﻿ * Copyright (C) 2015 Technical University of Liberec.  All rights reserved.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3 as published by the
+ * Free Software Foundation. (http://www.gnu.org/licenses/gpl-3.0.en.html)
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * 
+ * @file    general_iterator.hh
+ * @brief   Template GeneralIterator serves as general template for internal iterators.
+ */
+
+#ifndef GENERAL_ITERATOR_HH_
+#define GENERAL_ITERATOR_HH_
+
+/** @brief General iterator template.
+ * Provides iterator over objects in some container.
+ * 
+ * Requires the template object to implement:
+ * - comparison operator==()
+ * - increment operator++()
+ */
+template<class Object>
+class GeneralIterator
+{
+public:
+//     GeneralIterator();
+
+    GeneralIterator(const Object& object);
+
+    /// equal operator
+    bool operator==(const GeneralIterator& other);
+    /// non-equal operator
+    bool operator!=(const GeneralIterator& other);
+
+    ///  * dereference operator
+    const Object& operator*() const;
+
+    /// -> dereference operator
+    const Object* operator->() const;
+
+    /// prefix increment
+    GeneralIterator& operator++();
+
+private:
+    /// Output element of the output mesh.
+    Object object_; 
+};
+
+
+// --------------------------------------------------- GeneralIterator INLINE implementation -----------
+// inline GeneralIterator::GeneralIterator()
+// {}
+
+template<class Object>
+inline GeneralIterator<Object>::GeneralIterator(const Object& object)
+: object_(object)
+{}
+
+template<class Object>
+inline bool GeneralIterator<Object>::operator==(const GeneralIterator& other)
+{
+    return (object_ == other.object_);
+}
+
+template<class Object>
+inline bool GeneralIterator<Object>::operator!=(const GeneralIterator& other)
+{
+    return !( *this == other);
+}
+
+template<class Object>
+inline const Object& GeneralIterator<Object>::operator*() const
+{
+    return object_;
+}
+
+template<class Object>
+inline const Object* GeneralIterator<Object>::operator->() const
+{
+    return &object_;
+}
+
+template<class Object>
+inline GeneralIterator<Object>& GeneralIterator<Object>::operator++()
+{
+    ++object_;
+    return (*this);
+}
+
+#endif // GENERAL_ITERATOR_HH_

--- a/src/tools/general_iterator.hh
+++ b/src/tools/general_iterator.hh
@@ -90,7 +90,7 @@ inline const Object* GeneralIterator<Object>::operator->() const
 template<class Object>
 inline GeneralIterator<Object>& GeneralIterator<Object>::operator++()
 {
-    ++object_;
+    object_.inc();
     return (*this);
 }
 

--- a/unit_tests/output/CMakeLists.txt
+++ b/unit_tests/output/CMakeLists.txt
@@ -22,3 +22,4 @@ add_test_directory("${libs}")
 
 define_mpi_test( output 1 )
 define_mpi_test( output_vtk 1)
+define_mpi_test( output_mesh 1)

--- a/unit_tests/output/output_mesh_test.cpp
+++ b/unit_tests/output/output_mesh_test.cpp
@@ -40,7 +40,7 @@ TEST(OutputMesh, create_identical)
     ifstream in(string(mesh_file).c_str());
     mesh->read_gmsh_from_stream(in);
     
-    OutputMesh* output_mesh = new OutputMesh(mesh);
+    auto output_mesh = std::make_shared<OutputMesh>(mesh);
     output_mesh->create_identical_mesh();
     
     std::cout << "nodes: ";
@@ -56,51 +56,52 @@ TEST(OutputMesh, create_identical)
     EXPECT_EQ(output_mesh->nodes_->n_values, mesh->n_nodes());
     EXPECT_EQ(output_mesh->offsets_->n_values, mesh->n_elements());
     
-    for(OutputElementIterator it = output_mesh->begin(); it != output_mesh->end(); ++it)
+    for(const auto &ele : *output_mesh)
     {
-        xprintf(Msg,"%d %dD n_%d |",it->idx(), it->dim(), it->n_nodes());
-        for(unsigned int i=0; i < it->n_nodes(); i++)
+        xprintf(Msg,"%d %dD n_%d |",ele.idx(), ele.dim(), ele.n_nodes());
+        for(unsigned int i=0; i < ele.n_nodes(); i++)
         {
-            xprintf(Msg," %d",it->node_index(i));
+            xprintf(Msg," %d",ele.node_index(i));
         }
         xprintf(Msg," |");
-        for(auto& v : it->vertex_list())
+        for(auto& v : ele.vertex_list())
         {
             xprintf(Msg," %f %f %f #",v[0], v[1], v[2]);
         }
         xprintf(Msg,"\n");
         
-        ElementAccessor<3> ele_acc = it->element_accessor();
-        EXPECT_EQ(it->dim(), ele_acc.dim());
-        EXPECT_EQ(it->centre()[0], ele_acc.centre()[0]);
-        EXPECT_EQ(it->centre()[1], ele_acc.centre()[1]);
-        EXPECT_EQ(it->centre()[2], ele_acc.centre()[2]);
+        ElementAccessor<3> ele_acc = ele.element_accessor();
+        EXPECT_EQ(ele.dim(), ele_acc.dim());
+        EXPECT_EQ(ele.centre()[0], ele_acc.centre()[0]);
+        EXPECT_EQ(ele.centre()[1], ele_acc.centre()[1]);
+        EXPECT_EQ(ele.centre()[2], ele_acc.centre()[2]);
     }
     
-    output_mesh->compute_discontinuous_data();
+    auto output_mesh_discont = std::make_shared<OutputMeshDiscontinuous>(mesh);
+    output_mesh_discont->create_mesh(output_mesh);
+    
     xprintf(Msg,"DISCONTINUOUS\n");
-    for(OutputElementIterator it = output_mesh->begin(); it != output_mesh->end(); ++it)
+    for(const auto &ele : *output_mesh_discont)
     {
-        xprintf(Msg,"%d %dD n_%d |",it->idx(), it->dim(), it->n_nodes());
-        for(unsigned int i=0; i < it->n_nodes(); i++)
+        xprintf(Msg,"%d %dD n_%d |",ele.idx(), ele.dim(), ele.n_nodes());
+        for(unsigned int i=0; i < ele.n_nodes(); i++)
         {
-            xprintf(Msg," %d",it->node_index_disc(i));
+            xprintf(Msg," %d",ele.node_index(i));
         }
         xprintf(Msg," |");
-        for(auto& v : it->vertex_list())
+        for(auto& v : ele.vertex_list())
         {
             xprintf(Msg," %f %f %f #",v[0], v[1], v[2]);
         }
         xprintf(Msg,"\n");
         
-        ElementAccessor<3> ele_acc = it->element_accessor();
-        EXPECT_EQ(it->dim(), ele_acc.dim());
-        EXPECT_EQ(it->centre()[0], ele_acc.centre()[0]);
-        EXPECT_EQ(it->centre()[1], ele_acc.centre()[1]);
-        EXPECT_EQ(it->centre()[2], ele_acc.centre()[2]);
+        ElementAccessor<3> ele_acc = ele.element_accessor();
+        EXPECT_EQ(ele.dim(), ele_acc.dim());
+        EXPECT_EQ(ele.centre()[0], ele_acc.centre()[0]);
+        EXPECT_EQ(ele.centre()[1], ele_acc.centre()[1]);
+        EXPECT_EQ(ele.centre()[2], ele_acc.centre()[2]);
     }
     
-    delete output_mesh;
     delete mesh;
 }
 

--- a/unit_tests/output/output_test.cpp
+++ b/unit_tests/output/output_test.cpp
@@ -243,7 +243,7 @@ public:
 		field.set_time(TimeGovernor(0.0, 1.0).step(), LimitSide::left);
         
         // create output mesh identical to computational mesh
-        this->output_mesh_ = new OutputMesh(my_mesh);
+        this->output_mesh_ = std::make_shared<OutputMesh>(my_mesh);
         this->output_mesh_->create_identical_mesh();
         // set validity of the output mesh for the current writing time
         this->is_output_mesh_valid_ = true;

--- a/unit_tests/output/output_test.cpp
+++ b/unit_tests/output/output_test.cpp
@@ -248,6 +248,9 @@ public:
         // set validity of the output mesh for the current writing time
         this->is_output_mesh_valid_ = true;
         
+        this->output_mesh_discont_ = std::make_shared<OutputMeshDiscontinuous>(my_mesh);
+        this->output_mesh_discont_->create_mesh(this->output_mesh_);
+        
 		{
 			this->compute_field_data(ELEM_DATA, field);
 			EXPECT_EQ(1, output_data_vec_[ELEM_DATA].size());

--- a/unit_tests/output/output_test.cpp
+++ b/unit_tests/output/output_test.cpp
@@ -14,6 +14,7 @@
 
 #include "io/output_time.hh"
 #include "io/output_data_base.hh"
+#include "io/output_mesh.hh"
 #include "tools/time_governor.hh"
 
 #include "mesh/mesh.h"
@@ -240,7 +241,13 @@ public:
 
 		field.set_mesh(*my_mesh);
 		field.set_time(TimeGovernor(0.0, 1.0).step(), LimitSide::left);
-
+        
+        // create output mesh identical to computational mesh
+        this->output_mesh_ = new OutputMesh(my_mesh);
+        this->output_mesh_->create_identical_mesh();
+        // set validity of the output mesh for the current writing time
+        this->is_output_mesh_valid_ = true;
+        
 		{
 			this->compute_field_data(ELEM_DATA, field);
 			EXPECT_EQ(1, output_data_vec_[ELEM_DATA].size());

--- a/unit_tests/output/output_test.cpp
+++ b/unit_tests/output/output_test.cpp
@@ -245,8 +245,6 @@ public:
         // create output mesh identical to computational mesh
         this->output_mesh_ = std::make_shared<OutputMesh>(my_mesh);
         this->output_mesh_->create_identical_mesh();
-        // set validity of the output mesh for the current writing time
-        this->is_output_mesh_valid_ = true;
         
         this->output_mesh_discont_ = std::make_shared<OutputMeshDiscontinuous>(my_mesh);
         this->output_mesh_discont_->create_mesh(this->output_mesh_);

--- a/unit_tests/output/output_vtk_test.cpp
+++ b/unit_tests/output/output_vtk_test.cpp
@@ -10,6 +10,7 @@
 #include <flow_gtest_mpi.hh>
 #include "io/output_time.hh"
 #include "io/output_vtk.hh"
+#include "io/output_mesh.hh"
 #include "mesh/mesh.h"
 #include "input/reader_to_storage.hh"
 #include "system/sys_profiler.hh"
@@ -38,6 +39,12 @@ public:
         this->_mesh = new Mesh();
         ifstream in(string(mesh_file).c_str());
         this->_mesh->read_gmsh_from_stream(in);
+        
+        // create output mesh identical to computational mesh
+        this->output_mesh_ = new OutputMesh(this->_mesh);
+        this->output_mesh_->create_identical_mesh();
+        // set validity of the output mesh for the current writing time
+        this->is_output_mesh_valid_ = true;
     }
 
     ~TestOutputVTK()

--- a/unit_tests/output/output_vtk_test.cpp
+++ b/unit_tests/output/output_vtk_test.cpp
@@ -43,8 +43,6 @@ public:
         // create output mesh identical to computational mesh
         this->output_mesh_ = std::make_shared<OutputMesh>(this->_mesh);
         this->output_mesh_->create_identical_mesh();
-        // set validity of the output mesh for the current writing time
-        this->is_output_mesh_valid_ = true;
     }
 
     ~TestOutputVTK()

--- a/unit_tests/output/output_vtk_test.cpp
+++ b/unit_tests/output/output_vtk_test.cpp
@@ -41,7 +41,7 @@ public:
         this->_mesh->read_gmsh_from_stream(in);
         
         // create output mesh identical to computational mesh
-        this->output_mesh_ = new OutputMesh(this->_mesh);
+        this->output_mesh_ = std::make_shared<OutputMesh>(this->_mesh);
         this->output_mesh_->create_identical_mesh();
         // set validity of the output mesh for the current writing time
         this->is_output_mesh_valid_ = true;


### PR DESCRIPTION
- create output mesh identical with computational one
- introduce output element and its iterator
- pass error_control_field (future usage in refinement)
- compute field data on the output mesh
- unify writing data vectors in output_vtk
- get rid of mesh in output_vtk, use output mesh only

- class OutputMesh is still under construction (refinement)