### PR TITLE
Pe assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ doc/reference_manual/flow_version.tex
 .settings
 
 *.pyc
+*python.log
 /.idea/
 bin/pythonenv.sh
 tests/runtest.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(la_lib
     la/linsys_BDDC.cc
     la/linsys_PETSC.cc
     la/sparse_graph.cc
+    la/local_system.cc
 )
 target_link_libraries(la_lib 
     input_lib system_lib

--- a/src/flow/assembly_lmh.hh
+++ b/src/flow/assembly_lmh.hh
@@ -162,14 +162,14 @@ public:
                                   + diagonal_coef * water_content_diff / this->ad_->time_step_;
 
 
-                system_.lin_sys->mat_set_value(edge_row, edge_row, -mass_diagonal/this->ad_->time_step_ );
-                system_.lin_sys->rhs_set_value(edge_row, -source_diagonal - mass_rhs);
+                ad_->lin_sys->mat_set_value(edge_row, edge_row, -mass_diagonal/this->ad_->time_step_ );
+                ad_->lin_sys->rhs_set_value(edge_row, -source_diagonal - mass_rhs);
             }
 
-            if (system_.balance != nullptr) {
-                system_.balance->add_mass_vec_value(ad_->water_balance_idx_, ele.region().bulk_idx(),
+            if (ad_->balance != nullptr) {
+                ad_->balance->add_mass_vec_value(ad_->water_balance_idx, ele.region().bulk_idx(),
                         diagonal_coef*ad_->water_content_previous_it[local_side]);
-                system_.balance->add_source_vec_values(ad_->water_balance_idx_, ele.region().bulk_idx(), {(int)edge_row}, {source_diagonal});
+                ad_->balance->add_source_vec_values(ad_->water_balance_idx, ele.region().bulk_idx(), {(int)edge_row}, {source_diagonal});
             }
         }
 

--- a/src/flow/assembly_lmh.hh
+++ b/src/flow/assembly_lmh.hh
@@ -8,11 +8,13 @@
 #ifndef SRC_FLOW_ASSEMBLY_LMH_HH_
 #define SRC_FLOW_ASSEMBLY_LMH_HH_
 
-#include "flow/darcy_flow_assembly.hh"
+#include "darcy_flow_assembly.hh"
 #include "soil_models.hh"
+#include "richards_lmh.hh"
 
+#include "coupling/balance.hh"
 
-
+#include "badiff.h"
 
 /**
  * Prove of concept for general assembly scheme.

--- a/src/flow/darcy_flow_assembler.hh
+++ b/src/flow/darcy_flow_assembler.hh
@@ -1,0 +1,175 @@
+
+
+
+#ifndef DARCY_FLOW_ASSEMBLER_HH_
+#define DARCY_FLOW_ASSEMBLER_HH_
+
+#include "darcy_flow_mh.hh"
+#include "darcy_flow_assembly.hh"
+#include "assembly_lmh.hh"
+
+
+class AssemblerBase
+{
+public:
+    typedef std::shared_ptr<DarcyMH::EqData> AssemblyDataPtr;
+    typedef std::vector<std::shared_ptr<AssemblyBase> > MultidimAssembly;
+
+    AssemblerBase(AssemblyDataPtr d)
+    : ad_(d), local_boundary_index(0)
+    {}
+    
+    virtual ~AssemblerBase(){}
+    
+    AssemblyDataPtr ad_;
+    MultidimAssembly dim_assembler;
+    
+    void assemble(LocalElementAccessorBase<3> ele_ac, bool fill_matrix = true){
+        
+        unsigned int dim = ele_ac.dim();
+        dim_assembler[dim-1]->assemble(ele_ac,fill_matrix);
+        ad_->lin_sys->set_local_system(dim_assembler[dim-1]->get_local_system());
+        
+        assembly_dim_connections(ele_ac,fill_matrix);
+        
+        schur_allocations(ele_ac);
+        
+        if (ad_->balance != nullptr && fill_matrix)
+            add_fluxes_in_balance_matrix(ele_ac);
+    }
+    
+protected:
+    /// Auxiliary counter for boundary balance.
+    unsigned int local_boundary_index;
+    
+    void add_fluxes_in_balance_matrix(LocalElementAccessorBase<3> ele_ac){
+        
+        for (unsigned int i = 0; i < ele_ac.n_sides(); i++) {
+            Boundary* bcd = ele_ac.side(i)->cond();
+
+            if (bcd) {
+                /*
+                    DebugOut()("add_flux: {} {} {} {}\n",
+                            mh_dh.el_ds->myp(),
+                            ele_ac.ele_global_idx(),
+                            local_boundary_index,
+                            side_row);*/
+                ad_->balance->add_flux_matrix_values(ad_->water_balance_idx, local_boundary_index,
+                                                     {ele_ac.side_row(i)}, {1});
+                ++local_boundary_index;
+            }
+        }
+    }
+    
+    void assembly_dim_connections(LocalElementAccessorBase<3> ele_ac, bool fill_matrix){
+        //D, E',E block: compatible connections: element-edge
+        int ele_row = ele_ac.ele_row();
+        
+        int tmp_rows[2];
+        double local_vb[4]; // 2x2 matrix
+        Neighbour *ngh;
+    
+        for (unsigned int i = 0; i < ele_ac.full_iter()->n_neighs_vb; i++) {
+            // every compatible connection adds a 2x2 matrix involving
+            // current element pressure  and a connected edge pressure
+            ngh= ele_ac.full_iter()->neigh_vb[i];
+            tmp_rows[0]=ele_row;
+            tmp_rows[1]=ad_->mh_dh->row_4_edge[ ngh->edge_idx() ];
+            
+            if (fill_matrix)
+                dim_assembler[ngh->side()->dim()]->assembly_local_vb(local_vb, ele_ac.full_iter(), ngh);
+            
+            ad_->lin_sys->mat_set_values(2, tmp_rows, 2, tmp_rows, local_vb);
+
+            // update matrix for weights in BDDCML
+            if ( typeid(*ad_->lin_sys) == typeid(LinSys_BDDC) ) {
+               int ind = tmp_rows[1];
+               // there is -value on diagonal in block C!
+               double new_val = local_vb[0];
+               static_cast<LinSys_BDDC*>(ad_->lin_sys)->diagonal_weights_set_value( ind, new_val );
+            }
+        }
+    }
+    
+    void schur_allocations(LocalElementAccessorBase<3> ele_ac){
+            
+            //D, E',E block: compatible connections: element-edge
+            LinSys* ls = ad_->lin_sys;
+            Neighbour *ngh;
+            int ele_row = ele_ac.ele_row();
+            unsigned int nsides = ele_ac.n_sides();
+            
+            // edge dofs are saved in local system
+            LocalSystem& loc = dim_assembler[ele_ac.dim()-1]->get_local_system();
+            int* edge_rows = & loc.row_dofs[ele_ac.dim() + 2];
+            
+            int tmp_rows[100];
+            // to make space for second schur complement, max. 10 neighbour edges of one el.
+            double zeros[1000];
+            for(int i=0; i<1000; i++) zeros[i]=0.0;
+            
+            // D block:  diagonal: element-element
+            //TODO: local system is dense; correct when it is sparse
+            ls->mat_set_value(ele_row, ele_row, 0.0);         // maybe this should be in virtual block for schur preallocation
+            
+            for (unsigned int i = 0; i < ele_ac.full_iter()->n_neighs_vb; i++) {
+                // every compatible connection adds a 2x2 matrix involving
+                // current element pressure  and a connected edge pressure
+                ngh= ele_ac.full_iter()->neigh_vb[i];
+                tmp_rows[0]=ele_row;
+                tmp_rows[1]=ad_->mh_dh->row_4_edge[ ngh->edge_idx() ];
+
+                if (ad_->n_schur_compls == 2) {
+                    // for 2. Schur: N dim edge is conected with N dim element =>
+                    // there are nz between N dim edge and N-1 dim edges of the element
+
+                    ls->mat_set_values(nsides, edge_rows, 1, tmp_rows+1, zeros);
+                    ls->mat_set_values(1, tmp_rows+1, nsides, edge_rows, zeros);
+
+                    // save all global edge indices to higher positions
+                    tmp_rows[2+i] = tmp_rows[1];
+                }
+            }
+                // add virtual values for schur complement allocation
+            uint n_neigh;
+            switch (ad_->n_schur_compls) {
+            case 2:
+                n_neigh = ele_ac.full_iter()->n_neighs_vb;
+                // Connections between edges of N+1 dim. elements neighboring with actual N dim element 'ele'
+                OLD_ASSERT(n_neigh*n_neigh<1000, "Too many values in E block.");
+                ls->mat_set_values(ele_ac.full_iter()->n_neighs_vb, tmp_rows+2,
+                        ele_ac.full_iter()->n_neighs_vb, tmp_rows+2, zeros);
+
+            case 1: // included also for case 2
+                // -(C')*(A-)*B block and its transpose conect edge with its elements
+                ls->mat_set_values(1, &ele_row, nsides, edge_rows, zeros);
+                ls->mat_set_values(nsides, edge_rows, 1, &ele_row, zeros);
+                // -(C')*(A-)*C block conect all edges of every element
+                ls->mat_set_values(nsides, edge_rows, nsides, edge_rows, zeros);
+            }
+        }
+    
+};
+
+class AssemblerMH : public AssemblerBase
+{
+public:
+    AssemblerMH(AssemblyDataPtr d)
+    : AssemblerBase(d)
+    {
+        dim_assembler = AssemblyBase::create< AssemblyMH >(d);
+    }
+};
+
+class AssemblerLMH : public AssemblerBase
+{
+public:
+    AssemblerLMH(AssemblyDataPtr d)
+    : AssemblerBase(d)
+    {
+        dim_assembler = AssemblyBase::create< AssemblyMH >(d);
+    }
+};
+
+
+#endif // DARCY_FLOW_ASSEMBLER_HH_

--- a/src/flow/darcy_flow_assembler.hh
+++ b/src/flow/darcy_flow_assembler.hh
@@ -164,10 +164,10 @@ public:
 class AssemblerLMH : public AssemblerBase
 {
 public:
-    AssemblerLMH(AssemblyDataPtr d)
+    AssemblerLMH(std::shared_ptr<RichardsLMH::EqData> d)
     : AssemblerBase(d)
     {
-        dim_assembler = AssemblyBase::create< AssemblyMH >(d);
+        dim_assembler = AssemblyBase::create< AssemblyLMH >(d);
     }
 };
 

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -349,14 +349,14 @@ void DarcyMH::initialize() {
     balance_->init_from_input(input_record_.val<Input::Record>("balance"), time());
     if (balance_)
     {
-        data_-> water_balance_idx_ = water_balance_idx_ = balance_->add_quantity("water_volume");
+        data_-> water_balance_idx = water_balance_idx_ = balance_->add_quantity("water_volume");
         balance_->allocate(mh_dh.rows_ds->lsize(), 1);
         balance_->units(UnitSI().m(3));
     }
 
 
-    data_->system_.balance = balance_;
-    data_->system_.lin_sys = schur0;
+    data_->balance = balance_;
+    data_->lin_sys = schur0;
 
 
     initialize_specific();

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -639,7 +639,7 @@ void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler)
 
     // set auxiliary flag for switchting Dirichlet like BC
 //     data_->force_bc_switch = use_steady_assembly_ && (nonlinear_iteration_ == 0);
-    
+    data_->n_schur_compls = n_schur_compls;
     LinSys *ls = schur0;
 
     class Boundary *bcd;

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -1352,6 +1352,7 @@ void DarcyMH::print_matlab_matrix(std::string matlab_file)
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, matlab_file.c_str(), &viewer);
     PetscViewerSetFormat(viewer, PETSC_VIEWER_ASCII_MATLAB);
     MatView( *const_cast<Mat*>(schur0->get_matrix()), viewer);
+    VecView( *const_cast<Vec*>(schur0->get_rhs()), viewer);
     
     // compute h_min for different dimensions
     double d_max = std::numeric_limits<double>::max();

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -309,6 +309,8 @@ void DarcyMH::init_eq_data()
 
     data_->set_input_list( this->input_record_.val<Input::Array>("input_fields") );
     data_->mark_input_times(*time_);
+    // Initialize bc_switch_dirichlet to size of global boundary.
+    data_->bc_switch_dirichlet.resize(mesh_->bc_elements.size(), 1);
 }
 
 
@@ -319,8 +321,6 @@ void DarcyMH::initialize() {
     output_object = new DarcyFlowMHOutput(this, input_record_);
 
     mh_dh.reinit(mesh_);
-    // Initialize bc_switch_dirichlet to size of global boundary.
-    bc_switch_dirichlet.resize(mesh_->bc_elements.size(), 1);
 
 
     nonlinear_iteration_=0;
@@ -345,17 +345,15 @@ void DarcyMH::initialize() {
 
     // initialization of balance object
     balance_ = std::make_shared<Balance>("water", mesh_);
+    data_->balance = balance_;
     balance_->init_from_input(input_record_.val<Input::Record>("balance"), time());
     if (balance_)
     {
-        data_-> water_balance_idx = water_balance_idx_ = balance_->add_quantity("water_volume");
+        data_->water_balance_idx = water_balance_idx_ = balance_->add_quantity("water_volume");
         balance_->allocate(mh_dh.rows_ds->lsize(), 1);
         balance_->units(UnitSI().m(3));
     }
 
-
-    data_->balance = balance_;
-    data_->lin_sys = schur0;
 
 
     initialize_specific();
@@ -633,21 +631,24 @@ void DarcyMH::local_assembly_specific() {
 //
 // =======================================================================================
 
-void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler)
+void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler, bool fill_matrix)
 {
     START_TIMER("DarcyFlowMH_Steady::assembly_steady_mh_matrix");
 
-    // set auxiliary flag for switchting Dirichlet like BC
-//     data_->force_bc_switch = use_steady_assembly_ && (nonlinear_iteration_ == 0);
     data_->n_schur_compls = n_schur_compls;
+    data_->force_bc_switch = use_steady_assembly_ && (nonlinear_iteration_ == 0);
+
     LinSys *ls = schur0;
+    data_->lin_sys = schur0;    //TODO: make also shared pointer like balance and set before
+    data_->balance = balance_;
 
     class Boundary *bcd;
     class Neighbour *ngh;
 
-    bool fill_matrix = assembler.size() > 0;
+//     bool fill_matrix = assembler.size() > 0;
     int side_row, edge_row, loc_b = 0;
-    int tmp_rows[100];
+//     int tmp_rows[100];
+    int tmp_rows[2];
     double local_vb[4]; // 2x2 matrix
     int side_rows[4], edge_rows[4];
 
@@ -656,9 +657,9 @@ void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler)
     for(int i=0; i<1000; i++) zeros[i]=0.0;
 
     double minus_ones[4] = { -1.0, -1.0, -1.0, -1.0 };
-    double * loc_side_rhs = data_->system_.loc_side_rhs;
+//     double * loc_side_rhs = data_->system_.loc_side_rhs;
 
-    arma::mat &local_matrix = *(data_->system_.local_matrix);
+//     arma::mat &local_matrix = *(data_->system_.local_matrix);
 
 
     if (balance_ != nullptr && fill_matrix)
@@ -668,144 +669,145 @@ void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler)
         auto ele_ac = mh_dh.accessor(i_loc);
         unsigned int nsides = ele_ac.n_sides();
         data_->system_.dirichlet_edge.resize(nsides);
-
         
-
+        bool show_matrix = false;
         for (unsigned int i = 0; i < nsides; i++) {
-
-/*            if (! side_ds->is_local(idx_side)) {
-                cout << el_ds->myp() << " : iside: " << ele.index() << " [" << el_ds->begin() << ", " << el_ds->end() << "]" << endl;
-                cout << el_ds->myp() << " : iside: " << idx_side << " [" << side_ds->begin() << ", " << side_ds->end() << "]" << endl;
-
-            }*/
-
+// 
+// /*            if (! side_ds->is_local(idx_side)) {
+//                 cout << el_ds->myp() << " : iside: " << ele.index() << " [" << el_ds->begin() << ", " << el_ds->end() << "]" << endl;
+//                 cout << el_ds->myp() << " : iside: " << idx_side << " [" << side_ds->begin() << ", " << side_ds->end() << "]" << endl;
+// 
+//             }*/
+// 
             side_rows[i] = side_row = ele_ac.side_row(i);
             edge_rows[i] = edge_row = ele_ac.edge_row(i);
             bcd=ele_ac.side(i)->cond();
-
-            // gravity term on RHS
-            //
-            loc_side_rhs[i] = 0;
-
-            // set block C and C': side-edge, edge-side
-            double c_val = 1.0;
-            data_->system_.dirichlet_edge[i] = 0;
-
+// 
+//             // gravity term on RHS
+//             //
+//             loc_side_rhs[i] = 0;
+// 
+//             // set block C and C': side-edge, edge-side
+//             double c_val = 1.0;
+//             data_->system_.dirichlet_edge[i] = 0;
+// 
             if (bcd) {
-                ElementAccessor<3> b_ele = bcd->element_accessor();
-                EqData::BC_Type type = (EqData::BC_Type)data_->bc_type.value(b_ele.centre(), b_ele);
-
-                double cross_section = data_->cross_section.value(ele_ac.centre(), ele_ac.element_accessor());
-
-                if ( type == EqData::none) {
-                    // homogeneous neumann
-                } else if ( type == EqData::dirichlet ) {
-                    double bc_pressure = data_->bc_pressure.value(b_ele.centre(), b_ele);
-                    c_val = 0.0;
-                    loc_side_rhs[i] -= bc_pressure;
-                    ls->rhs_set_value(edge_row, -bc_pressure);
-                    ls->mat_set_value(edge_row, edge_row, -1.0);
-                    data_->system_.dirichlet_edge[i] = 1;
-
-                } else if ( type == EqData::total_flux) {
-                    // internally we work with outward flux
-                    double bc_flux = -data_->bc_flux.value(b_ele.centre(), b_ele);
-                    double bc_pressure = data_->bc_pressure.value(b_ele.centre(), b_ele);
-                            double bc_sigma = data_->bc_robin_sigma.value(b_ele.centre(), b_ele);
-                            ls->mat_set_value(edge_row, edge_row, -bcd->element()->measure() * bc_sigma * cross_section );
-                            ls->rhs_set_value(edge_row, (bc_flux - bc_sigma * bc_pressure) * bcd->element()->measure() * cross_section);
-
-                } else if (type==EqData::seepage) {
-                    data_->is_linear=false;
-                    //unsigned int loc_edge_idx = edge_row - rows_ds->begin() - side_ds->lsize() - el_ds->lsize();
-                    unsigned int loc_edge_idx = bcd->bc_ele_idx_;
-                    char & switch_dirichlet = bc_switch_dirichlet[loc_edge_idx];
-                    double bc_pressure = data_->bc_switch_pressure.value(b_ele.centre(), b_ele);
-                    double bc_flux = -data_->bc_flux.value(b_ele.centre(), b_ele);
-                    double side_flux=bc_flux * bcd->element()->measure() * cross_section;
-
-                    // ** Update BC type. **
-                    if (switch_dirichlet) {
-                        // check and possibly switch to flux BC
-                        // The switch raise error on the corresponding edge row.
-                        // Magnitude of the error is abs(solution_flux - side_flux).
-                        ASSERT_DBG(mh_dh.rows_ds->is_local(side_row))(side_row);
-                        unsigned int loc_side_row = ele_ac.side_local_row(i);
-                        double & solution_flux = ls->get_solution_array()[loc_side_row];
-
-                        if ( solution_flux < side_flux) {
-                            //DebugOut().fmt("x: {}, to neum, p: {} f: {} -> f: {}\n", b_ele.centre()[0], bc_pressure, solution_flux, side_flux);
-                            solution_flux = side_flux;
-                            switch_dirichlet=0;
-
-                        }
-                    } else {
-                        // check and possibly switch to  pressure BC
-                        // TODO: What is the appropriate DOF in not local?
-                        // The switch raise error on the corresponding side row.
-                        // Magnitude of the error is abs(solution_head - bc_pressure)
-                        // Since usually K is very large, this error would be much
-                        // higher then error caused by the inverse switch, this
-                        // cause that a solution  with the flux violating the
-                        // flux inequality leading may be accepted, while the error
-                        // in pressure inequality is always satisfied.
-                        ASSERT_DBG(mh_dh.rows_ds->is_local(edge_row))(edge_row);
-                        unsigned int loc_edge_row = ele_ac.edge_local_row(i);
-                        double & solution_head = ls->get_solution_array()[loc_edge_row];
-
-                        if ( solution_head > bc_pressure) {
-                            //DebugOut().fmt("x: {}, to dirich, p: {} -> p: {} f: {}\n",b_ele.centre()[0], solution_head, bc_pressure, bc_flux);
-                            solution_head = bc_pressure;
-                            switch_dirichlet=1;
-                        }
-                    }
-
-                    // ** Apply BCUpdate BC type. **
-                    // Force Dirichlet type during the first iteration of the unsteady case.
-                    if (switch_dirichlet || data_->force_bc_switch ) {
-                        //DebugOut().fmt("x: {}, dirich, bcp: {}\n", b_ele.centre()[0], bc_pressure);
-                        c_val = 0.0;
-                        loc_side_rhs[i] -= bc_pressure;
-                        ls->rhs_set_value(edge_row, -bc_pressure);
-                        ls->mat_set_value(edge_row, edge_row, -1.0);
-                        data_->system_.dirichlet_edge[i] = 1;
-                    } else {
-                        //DebugOut()("x: {}, neuman, q: {}  bcq: {}\n", b_ele.centre()[0], side_flux, bc_flux);
-                        ls->rhs_set_value(edge_row, side_flux);
-                    }
-
-                } else if (type==EqData::river) {
-                    data_->is_linear=false;
-                    //unsigned int loc_edge_idx = edge_row - rows_ds->begin() - side_ds->lsize() - el_ds->lsize();
-                    //unsigned int loc_edge_idx = bcd->bc_ele_idx_;
-                    //char & switch_dirichlet = bc_switch_dirichlet[loc_edge_idx];
-
-                    double bc_pressure = data_->bc_pressure.value(b_ele.centre(), b_ele);
-                    double bc_switch_pressure = data_->bc_switch_pressure.value(b_ele.centre(), b_ele);
-                    double bc_flux = -data_->bc_flux.value(b_ele.centre(), b_ele);
-                    double bc_sigma = data_->bc_robin_sigma.value(b_ele.centre(), b_ele);
-                    ASSERT_DBG(mh_dh.rows_ds->is_local(edge_row))(edge_row);
-                    unsigned int loc_edge_row = ele_ac.edge_local_row(i);
-                    double & solution_head = ls->get_solution_array()[loc_edge_row];
-
-
-                    // Force Robin type during the first iteration of the unsteady case.
-                    if (solution_head > bc_switch_pressure  || data_->force_bc_switch) {
-                        // Robin BC
-                        //DebugOut().fmt("x: {}, robin, bcp: {}\n", b_ele.centre()[0], bc_pressure);
-                        ls->rhs_set_value(edge_row, bcd->element()->measure() * cross_section * (bc_flux - bc_sigma * bc_pressure)  );
-                        ls->mat_set_value(edge_row, edge_row, -bcd->element()->measure() * bc_sigma * cross_section );
-                    } else {
-                        // Neumann BC
-                        //DebugOut().fmt("x: {}, neuman, q: {}  bcq: {}\n", b_ele.centre()[0], bc_switch_pressure, bc_pressure);
-                        double bc_total_flux = bc_flux + bc_sigma*(bc_switch_pressure - bc_pressure);
-                        ls->rhs_set_value(edge_row, bc_total_flux * bcd->element()->measure() * cross_section);
-                    }
-                } else {
-                    xprintf(UsrErr, "BC type not supported.\n");
-                }
-
-                if (balance_ != nullptr && fill_matrix)
+                show_matrix = true;
+//                 ElementAccessor<3> b_ele = bcd->element_accessor();
+//                 EqData::BC_Type type = (EqData::BC_Type)data_->bc_type.value(b_ele.centre(), b_ele);
+//                 if ( type == EqData::total_flux) show_matrix = true;
+// 
+//                 double cross_section = data_->cross_section.value(ele_ac.centre(), ele_ac.element_accessor());
+// 
+//                 if ( type == EqData::none) {
+//                     // homogeneous neumann
+//                 } else if ( type == EqData::dirichlet ) {
+//                     double bc_pressure = data_->bc_pressure.value(b_ele.centre(), b_ele);
+//                     c_val = 0.0;
+//                     loc_side_rhs[i] -= bc_pressure;
+//                     ls->rhs_set_value(edge_row, -bc_pressure);
+//                     ls->mat_set_value(edge_row, edge_row, -1.0);
+//                     data_->system_.dirichlet_edge[i] = 1;
+// 
+//                 } else if ( type == EqData::total_flux) {
+//                     // internally we work with outward flux
+//                     double bc_flux = -data_->bc_flux.value(b_ele.centre(), b_ele);
+//                     double bc_pressure = data_->bc_pressure.value(b_ele.centre(), b_ele);
+//                             double bc_sigma = data_->bc_robin_sigma.value(b_ele.centre(), b_ele);
+//                             ls->mat_set_value(edge_row, edge_row, -bcd->element()->measure() * bc_sigma * cross_section );
+//                             ls->rhs_set_value(edge_row, (bc_flux - bc_sigma * bc_pressure) * bcd->element()->measure() * cross_section);
+// 
+//                 } else if (type==EqData::seepage) {
+//                     data_->is_linear=false;
+//                     //unsigned int loc_edge_idx = edge_row - rows_ds->begin() - side_ds->lsize() - el_ds->lsize();
+//                     unsigned int loc_edge_idx = bcd->bc_ele_idx_;
+//                     char & switch_dirichlet = data_->bc_switch_dirichlet[loc_edge_idx];
+//                     double bc_pressure = data_->bc_switch_pressure.value(b_ele.centre(), b_ele);
+//                     double bc_flux = -data_->bc_flux.value(b_ele.centre(), b_ele);
+//                     double side_flux=bc_flux * bcd->element()->measure() * cross_section;
+// 
+//                     // ** Update BC type. **
+//                     if (switch_dirichlet) {
+//                         // check and possibly switch to flux BC
+//                         // The switch raise error on the corresponding edge row.
+//                         // Magnitude of the error is abs(solution_flux - side_flux).
+//                         ASSERT_DBG(mh_dh.rows_ds->is_local(side_row))(side_row);
+//                         unsigned int loc_side_row = ele_ac.side_local_row(i);
+//                         double & solution_flux = ls->get_solution_array()[loc_side_row];
+// 
+//                         if ( solution_flux < side_flux) {
+//                             //DebugOut().fmt("x: {}, to neum, p: {} f: {} -> f: {}\n", b_ele.centre()[0], bc_pressure, solution_flux, side_flux);
+//                             solution_flux = side_flux;
+//                             switch_dirichlet=0;
+// 
+//                         }
+//                     } else {
+//                         // check and possibly switch to  pressure BC
+//                         // TODO: What is the appropriate DOF in not local?
+//                         // The switch raise error on the corresponding side row.
+//                         // Magnitude of the error is abs(solution_head - bc_pressure)
+//                         // Since usually K is very large, this error would be much
+//                         // higher then error caused by the inverse switch, this
+//                         // cause that a solution  with the flux violating the
+//                         // flux inequality leading may be accepted, while the error
+//                         // in pressure inequality is always satisfied.
+//                         ASSERT_DBG(mh_dh.rows_ds->is_local(edge_row))(edge_row);
+//                         unsigned int loc_edge_row = ele_ac.edge_local_row(i);
+//                         double & solution_head = ls->get_solution_array()[loc_edge_row];
+// 
+//                         if ( solution_head > bc_pressure) {
+//                             //DebugOut().fmt("x: {}, to dirich, p: {} -> p: {} f: {}\n",b_ele.centre()[0], solution_head, bc_pressure, bc_flux);
+//                             solution_head = bc_pressure;
+//                             switch_dirichlet=1;
+//                         }
+//                     }
+// 
+//                     // ** Apply BCUpdate BC type. **
+//                     // Force Dirichlet type during the first iteration of the unsteady case.
+//                     if (switch_dirichlet || data_->force_bc_switch ) {
+//                         //DebugOut().fmt("x: {}, dirich, bcp: {}\n", b_ele.centre()[0], bc_pressure);
+//                         c_val = 0.0;
+//                         loc_side_rhs[i] -= bc_pressure;
+//                         ls->rhs_set_value(edge_row, -bc_pressure);
+//                         ls->mat_set_value(edge_row, edge_row, -1.0);
+//                         data_->system_.dirichlet_edge[i] = 1;
+//                     } else {
+//                         //DebugOut()("x: {}, neuman, q: {}  bcq: {}\n", b_ele.centre()[0], side_flux, bc_flux);
+//                         ls->rhs_set_value(edge_row, side_flux);
+//                     }
+// 
+//                 } else if (type==EqData::river) {
+//                     data_->is_linear=false;
+//                     //unsigned int loc_edge_idx = edge_row - rows_ds->begin() - side_ds->lsize() - el_ds->lsize();
+//                     //unsigned int loc_edge_idx = bcd->bc_ele_idx_;
+//                     //char & switch_dirichlet = bc_switch_dirichlet[loc_edge_idx];
+// 
+//                     double bc_pressure = data_->bc_pressure.value(b_ele.centre(), b_ele);
+//                     double bc_switch_pressure = data_->bc_switch_pressure.value(b_ele.centre(), b_ele);
+//                     double bc_flux = -data_->bc_flux.value(b_ele.centre(), b_ele);
+//                     double bc_sigma = data_->bc_robin_sigma.value(b_ele.centre(), b_ele);
+//                     ASSERT_DBG(mh_dh.rows_ds->is_local(edge_row))(edge_row);
+//                     unsigned int loc_edge_row = ele_ac.edge_local_row(i);
+//                     double & solution_head = ls->get_solution_array()[loc_edge_row];
+// 
+// 
+//                     // Force Robin type during the first iteration of the unsteady case.
+//                     if (solution_head > bc_switch_pressure  || data_->force_bc_switch) {
+//                         // Robin BC
+//                         //DebugOut().fmt("x: {}, robin, bcp: {}\n", b_ele.centre()[0], bc_pressure);
+//                         ls->rhs_set_value(edge_row, bcd->element()->measure() * cross_section * (bc_flux - bc_sigma * bc_pressure)  );
+//                         ls->mat_set_value(edge_row, edge_row, -bcd->element()->measure() * bc_sigma * cross_section );
+//                     } else {
+//                         // Neumann BC
+//                         //DebugOut().fmt("x: {}, neuman, q: {}  bcq: {}\n", b_ele.centre()[0], bc_switch_pressure, bc_pressure);
+//                         double bc_total_flux = bc_flux + bc_sigma*(bc_switch_pressure - bc_pressure);
+//                         ls->rhs_set_value(edge_row, bc_total_flux * bcd->element()->measure() * cross_section);
+//                     }
+//                 } else {
+//                     xprintf(UsrErr, "BC type not supported.\n");
+//                 }
+// 
+                if (data_->balance != nullptr && fill_matrix)
                 {
                    /*
                     DebugOut()("add_flux: {} {} {} {}\n",
@@ -813,60 +815,63 @@ void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler)
                             ele_ac.ele_global_idx(),
                             loc_b,
                             side_row);*/
-                    balance_->add_flux_matrix_values(water_balance_idx_, loc_b, {side_row}, {1});
+                    data_->balance->add_flux_matrix_values(data_->water_balance_idx, loc_b, {side_row}, {1});
                 }
                 ++loc_b;
             }
-            ls->mat_set_value(side_row, edge_row, c_val);
-            ls->mat_set_value(edge_row, side_row, c_val);
-
+//             ls->mat_set_value(side_row, edge_row, c_val);
+//             ls->mat_set_value(edge_row, side_row, c_val);
+// 
         }
-
-        if (fill_matrix) {
-            assembler[ele_ac.dim()-1]->assembly_local_matrix(ele_ac);
-
-            // assemble matrix for weights in BDDCML
-            // approximation to diagonal of 
-            // S = -C - B*inv(A)*B'
-            // as 
-            // diag(S) ~ - diag(C) - 1./diag(A)
-            // the weights form a partition of unity to average a discontinuous solution from neighbouring subdomains
-            // to a continuous one
-            // it is important to scale the effect - if conductivity is low for one subdomain and high for the other,
-            // trust more the one with low conductivity - it will be closer to the truth than an arithmetic average
-            if ( typeid(*ls) == typeid(LinSys_BDDC) ) {
-               for(unsigned int i=0; i < nsides; i++) {
-                   double val_side =  local_matrix(i,i);
-                   double val_edge =  -1./local_matrix(i,i);
-
-                   static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( side_rows[i], val_side );
-                   static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( edge_rows[i], val_edge );
-               }
-            }
-        }
-
-        ls->rhs_set_values(nsides, side_rows, loc_side_rhs);
-
+        
+        assembler[ele_ac.dim()-1]->assemble(ele_ac, fill_matrix);
+        assembler[ele_ac.dim()-1]->get_local_system().fix_diagonal();
+//         const arma::mat& local_matrix = assembler[ele_ac.dim()-1]->get_local_system().get_matrix();
+//         if(show_matrix) DBGCOUT(<< "\n" << local_matrix);
+//         if(show_matrix) DBGCOUT(<< assembler[ele_ac.dim()-1]->get_local_system().get_rhs());
+        
+//         if (fill_matrix) {
+//             // assemble matrix for weights in BDDCML
+//             // approximation to diagonal of 
+//             // S = -C - B*inv(A)*B'
+//             // as 
+//             // diag(S) ~ - diag(C) - 1./diag(A)
+//             // the weights form a partition of unity to average a discontinuous solution from neighbouring subdomains
+//             // to a continuous one
+//             // it is important to scale the effect - if conductivity is low for one subdomain and high for the other,
+//             // trust more the one with low conductivity - it will be closer to the truth than an arithmetic average
+//             if ( typeid(*ls) == typeid(LinSys_BDDC) ) {
+//                for(unsigned int i=0; i < nsides; i++) {
+//                    double val_side =  local_matrix(i,i);
+//                    double val_edge =  -1./local_matrix(i,i);
+// 
+//                    static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( side_rows[i], val_side );
+//                    static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( edge_rows[i], val_edge );
+//                }
+//             }
+//         }
         
         // set block A: side-side on one element - block diagonal matrix
-        ls->mat_set_values(nsides, side_rows, nsides, side_rows, local_matrix.memptr());
-        // set block B, B': element-side, side-element
-        int ele_row = ele_ac.ele_row();
-        ls->mat_set_values(1, &ele_row, nsides, side_rows, minus_ones);
-        ls->mat_set_values(nsides, side_rows, 1, &ele_row, minus_ones);
-
-
-        // D block:  diagonal: element-element
-
-        ls->mat_set_value(ele_row, ele_row, 0.0);         // maybe this should be in virtual block for schur preallocation
-
-        if ( typeid(*ls) == typeid(LinSys_BDDC) ) {
-           double val_ele =  1.;
-           static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( ele_row, val_ele );
-        }
-
-        // D, E',E block: compatible connections: element-edge
+//         ls->mat_set_values(nsides, side_rows, nsides, side_rows, local_matrix.memptr());
+        ls->set_local_system(assembler[ele_ac.dim()-1]->get_local_system());
         
+//         // set block B, B': element-side, side-element
+//         int ele_row = ele_ac.ele_row();
+//         ls->mat_set_values(1, &ele_row, nsides, side_rows, minus_ones);
+//         ls->mat_set_values(nsides, side_rows, 1, &ele_row, minus_ones);
+// 
+// 
+//         // D block:  diagonal: element-element
+// 
+//         ls->mat_set_value(ele_row, ele_row, 0.0);         // maybe this should be in virtual block for schur preallocation
+// 
+//         if ( typeid(*ls) == typeid(LinSys_BDDC) ) {
+//            double val_ele =  1.;
+//            static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( ele_row, val_ele );
+//         }
+
+        //D, E',E block: compatible connections: element-edge
+        int ele_row = ele_ac.ele_row();
         for (unsigned int i = 0; i < ele_ac.full_iter()->n_neighs_vb; i++) {
             // every compatible connection adds a 2x2 matrix involving
             // current element pressure  and a connected edge pressure
@@ -886,37 +891,60 @@ void DarcyMH::assembly_mh_matrix(MultidimAssembler assembler)
                double new_val = local_vb[0];
                static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( ind, new_val );
             }
-
-            if (n_schur_compls == 2) {
-                // for 2. Schur: N dim edge is conected with N dim element =>
-                // there are nz between N dim edge and N-1 dim edges of the element
-
-                ls->mat_set_values(nsides, edge_rows, 1, tmp_rows+1, zeros);
-                ls->mat_set_values(1, tmp_rows+1, nsides, edge_rows, zeros);
-
-                // save all global edge indices to higher positions
-                tmp_rows[2+i] = tmp_rows[1];
-            }
         }
+        
+//         //D, E',E block: compatible connections: element-edge
+//         int ele_row = ele_ac.ele_row();
+//         for (unsigned int i = 0; i < ele_ac.full_iter()->n_neighs_vb; i++) {
+//             // every compatible connection adds a 2x2 matrix involving
+//             // current element pressure  and a connected edge pressure
+//             ngh= ele_ac.full_iter()->neigh_vb[i];
+//             tmp_rows[0]=ele_row;
+//             tmp_rows[1]=mh_dh.row_4_edge[ ngh->edge_idx() ];
+//             
+//             if (fill_matrix)
+//                 assembler[ngh->side()->dim()]->assembly_local_vb(local_vb, ele_ac.full_iter(), ngh);
+//             
+//             ls->mat_set_values(2, tmp_rows, 2, tmp_rows, local_vb);
+// 
+//             // update matrix for weights in BDDCML
+//             if ( typeid(*ls) == typeid(LinSys_BDDC) ) {
+//                int ind = tmp_rows[1];
+//                // there is -value on diagonal in block C!
+//                double new_val = local_vb[0];
+//                static_cast<LinSys_BDDC*>(ls)->diagonal_weights_set_value( ind, new_val );
+//             }
+// 
+//             if (n_schur_compls == 2) {
+//                 // for 2. Schur: N dim edge is conected with N dim element =>
+//                 // there are nz between N dim edge and N-1 dim edges of the element
+// 
+//                 ls->mat_set_values(nsides, edge_rows, 1, tmp_rows+1, zeros);
+//                 ls->mat_set_values(1, tmp_rows+1, nsides, edge_rows, zeros);
+// 
+//                 // save all global edge indices to higher positions
+//                 tmp_rows[2+i] = tmp_rows[1];
+//             }
+//         }
 
 
-        // add virtual values for schur complement allocation
-        uint n_neigh;
-        switch (n_schur_compls) {
-        case 2:
-            n_neigh = ele_ac.full_iter()->n_neighs_vb;
-            // Connections between edges of N+1 dim. elements neighboring with actual N dim element 'ele'
-        	OLD_ASSERT(n_neigh*n_neigh<1000, "Too many values in E block.");
-            ls->mat_set_values(ele_ac.full_iter()->n_neighs_vb, tmp_rows+2,
-                    ele_ac.full_iter()->n_neighs_vb, tmp_rows+2, zeros);
-
-        case 1: // included also for case 2
-            // -(C')*(A-)*B block and its transpose conect edge with its elements
-            ls->mat_set_values(1, &ele_row, ele_ac.n_sides(), edge_rows, zeros);
-            ls->mat_set_values(ele_ac.n_sides(), edge_rows, 1, &ele_row, zeros);
-            // -(C')*(A-)*C block conect all edges of every element
-            ls->mat_set_values(ele_ac.n_sides(), edge_rows, ele_ac.n_sides(), edge_rows, zeros);
-        }
+//         // add virtual values for schur complement allocation
+//         uint n_neigh;
+//         switch (n_schur_compls) {
+//         case 2:
+//             n_neigh = ele_ac.full_iter()->n_neighs_vb;
+//             // Connections between edges of N+1 dim. elements neighboring with actual N dim element 'ele'
+//         	OLD_ASSERT(n_neigh*n_neigh<1000, "Too many values in E block.");
+//             ls->mat_set_values(ele_ac.full_iter()->n_neighs_vb, tmp_rows+2,
+//                     ele_ac.full_iter()->n_neighs_vb, tmp_rows+2, zeros);
+// 
+//         case 1: // included also for case 2
+//             // -(C')*(A-)*B block and its transpose conect edge with its elements
+//             ls->mat_set_values(1, &ele_row, ele_ac.n_sides(), edge_rows, zeros);
+//             ls->mat_set_values(ele_ac.n_sides(), edge_rows, 1, &ele_row, zeros);
+//             // -(C')*(A-)*C block conect all edges of every element
+//             ls->mat_set_values(ele_ac.n_sides(), edge_rows, ele_ac.n_sides(), edge_rows, zeros);
+//         }
     }    
     
     if (balance_ != nullptr && fill_matrix)
@@ -1275,7 +1303,9 @@ void DarcyMH::create_linear_system(Input::AbstractRecord in_rec) {
             START_TIMER("PETSC PREALLOCATION");
             schur0->set_symmetric();
             schur0->start_allocation();
-            assembly_mh_matrix(MultidimAssembler()); // preallocation
+            auto multidim_assembler = AssemblyBase::create< AssemblyMH >(data_);
+//             assembly_mh_matrix(MultidimAssembler()); // preallocation
+            assembly_mh_matrix(multidim_assembler, false); // preallocation
     	    VecZeroEntries(schur0->get_solution());
             END_TIMER("PETSC PREALLOCATION");
         }
@@ -1348,6 +1378,11 @@ void DarcyMH::assembly_linear_system() {
 
 void DarcyMH::print_matlab_matrix(std::string matlab_file)
 {
+    if ( typeid(*schur0) == typeid(LinSys_BDDC) ){
+        DebugOut() << "LinSys BDDC does not implement get_matrix().";
+        return;
+    }
+    
     PetscViewer    viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, matlab_file.c_str(), &viewer);
     PetscViewerSetFormat(viewer, PETSC_VIEWER_ASCII_MATLAB);

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -321,7 +321,6 @@ void DarcyMH::initialize() {
 
     // auxiliary set_time call  since allocation assembly evaluates fields as well
     data_->set_time(time_->step(), LimitSide::right);
-    data_->system_.local_matrix = std::make_shared<arma::mat>();
     create_linear_system(rec);
 
 

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -59,7 +59,7 @@ class LocalToGlobalMap;
 class DarcyFlowMHOutput;
 class Balance;
 class VectorSeqDouble;
-class AssemblyBase;
+class AssemblerBase;
 
 template<unsigned int dim, unsigned int spacedim> class FE_RT0;
 template<unsigned int degree, unsigned int dim, unsigned int spacedim> class FE_P_disc;
@@ -143,7 +143,6 @@ public:
             << "Diverged nonlinear solver. Reason: " << EI_Reason::val
              );
 
-    typedef std::vector<std::shared_ptr<AssemblyBase> > MultidimAssembler;
 
     /// Class with all fields used in the equation DarcyFlow.
     /// This is common to all implementations since this provides interface
@@ -315,7 +314,7 @@ protected:
      * - add support for Robin type sources
      * - support for nonlinear solvers - assembly either residual vector, matrix, or both (using FADBAD++)
      */
-    void assembly_mh_matrix( MultidimAssembler ma, bool fill_matrix = true);
+    void assembly_mh_matrix( AssemblerBase& ma, bool fill_matrix = true);
     
 
     /// Source term is implemented differently in LMH version.

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -95,8 +95,6 @@ public:
     std::vector<unsigned int> dirichlet_edge;
     std::shared_ptr<arma::mat> local_matrix;
     double loc_side_rhs[4];
-    std::shared_ptr<Balance> balance;
-    LinSys *lin_sys;
 };
 
 
@@ -197,7 +195,10 @@ public:
         MH_DofHandler *mh_dh;
 
         RichardsSystem system_;
-        uint water_balance_idx_;
+        uint water_balance_idx;
+        std::shared_ptr<Balance> balance;
+        LinSys *lin_sys;
+        
         //FieldSet  time_term_fields;
         //FieldSet  main_matrix_fields;
         //FieldSet  rhs_fields;

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -327,6 +327,9 @@ protected:
      * residual field, standard part of EqData.
      */
     virtual double solution_precision() const;
+    
+    /// Print darcy flow matrix in matlab format into a file.
+    void print_matlab_matrix(string matlab_file);
 
     bool solution_changed_for_scatter;
     //Vec velocity_vector;

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -199,6 +199,9 @@ public:
         std::shared_ptr<Balance> balance;
         LinSys *lin_sys;
         
+        int is_linear;              ///< Hack fo BDDC solver.
+        bool force_bc_switch;       ///< auxiliary flag for switchting Dirichlet like BC
+        
         //FieldSet  time_term_fields;
         //FieldSet  main_matrix_fields;
         //FieldSet  rhs_fields;
@@ -340,7 +343,6 @@ protected:
 	int size;				    // global size of MH matrix
 	int  n_schur_compls;  	    // number of shur complements to make
 	double  *solution; 			// sequantial scattered solution vector
-	int is_linear_;             // Hack fo BDDC solver.
 
 	// Propagate test for the time term to the assembly.
 	// This flag is necessary for switching BC to avoid setting zero neumann on the whole boundary in the steady case.

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -191,6 +191,8 @@ public:
         arma::vec4 gravity_;
         arma::vec3 gravity_vec_;
 
+    // Mirroring the following members of DarcyMH:
+        
         Mesh *mesh;
         MH_DofHandler *mh_dh;
 
@@ -206,6 +208,9 @@ public:
         //FieldSet  time_term_fields;
         //FieldSet  main_matrix_fields;
         //FieldSet  rhs_fields;
+        
+        /// Idicator of dirichlet or neumann type of switch boundary conditions.
+        std::vector<char> bc_switch_dirichlet;
     };
 
     /// Type of experimental Mortar-like method for non-compatible 1d-2d interaction.
@@ -310,7 +315,7 @@ protected:
      * - add support for Robin type sources
      * - support for nonlinear solvers - assembly either residual vector, matrix, or both (using FADBAD++)
      */
-    void assembly_mh_matrix( MultidimAssembler ma);
+    void assembly_mh_matrix( MultidimAssembler ma, bool fill_matrix = true);
     
 
     /// Source term is implemented differently in LMH version.
@@ -363,9 +368,6 @@ protected:
 
 	
 
-
-	/// Idicator of dirichlet or neumann type of switch boundary conditions.
-	std::vector<char> bc_switch_dirichlet;
 
 
 	// gather of the solution

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -83,22 +83,6 @@ template<unsigned int dim> class QGauss;
 
 
 /**
- * This should contain target large algebra object to be assembled.
- * Since this should be passed only once per the whole assembly and may be equation specific
- * this structure is passed with the data
- */
-class RichardsSystem {
-public:
-    // temporary solution how to pass information about dirichlet BC on edges
-    // should be done better when we move whole assembly into assembly classes
-    // the vector is set in assembly_mh_matrix and used in LMH assembly of the time term
-    std::vector<unsigned int> dirichlet_edge;
-    std::shared_ptr<arma::mat> local_matrix;
-    double loc_side_rhs[4];
-};
-
-
-/**
  * @brief Mixed-hybrid of steady Darcy flow with sources and variable density.
  *
  * solve equations:
@@ -195,7 +179,6 @@ public:
         Mesh *mesh;
         MH_DofHandler *mh_dh;
 
-        RichardsSystem system_;
         uint water_balance_idx;
         std::shared_ptr<Balance> balance;
         LinSys *lin_sys;

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -199,6 +199,7 @@ public:
         std::shared_ptr<Balance> balance;
         LinSys *lin_sys;
         
+        unsigned int n_schur_compls;
         int is_linear;              ///< Hack fo BDDC solver.
         bool force_bc_switch;       ///< auxiliary flag for switchting Dirichlet like BC
         

--- a/src/flow/richards_lmh.cc
+++ b/src/flow/richards_lmh.cc
@@ -211,7 +211,7 @@ void RichardsLMH::assembly_linear_system()
     VecScatterBegin(solution_2_edge_scatter_, schur0->get_solution(), data_->phead_edge_.petsc_vec() , INSERT_VALUES, SCATTER_FORWARD);
     VecScatterEnd(solution_2_edge_scatter_, schur0->get_solution(), data_->phead_edge_.petsc_vec() , INSERT_VALUES, SCATTER_FORWARD);
 
-    is_linear_ = data_->genuchten_p_head_scale.field_result(mesh_->region_db().get_region_set("BULK")) == result_zeros;
+    data_->is_linear = data_->genuchten_p_head_scale.field_result(mesh_->region_db().get_region_set("BULK")) == result_zeros;
 
     bool is_steady = zero_time_term();
     //DebugOut() << "Assembly linear system\n";

--- a/src/flow/richards_lmh.cc
+++ b/src/flow/richards_lmh.cc
@@ -32,7 +32,7 @@
 #include "badiff.h"
 #include "fadiff.h"
 
-#include "flow/assembly_lmh.hh"
+#include "flow/darcy_flow_assembler.hh"
 
 
 FLOW123D_FORCE_LINK_IN_CHILD(richards_lmh);
@@ -220,8 +220,8 @@ void RichardsLMH::assembly_linear_system()
             schur0->start_add_assembly(); // finish allocation and create matrix
         }
         data_->time_step_ = time_->dt();
-        auto multidim_assembler = AssemblyBase::create< AssemblyLMH >(data_);
-
+//         auto multidim_assembler = AssemblyBase::create< AssemblyLMH >(data_);
+        auto multidim_assembler = AssemblerLMH(data_);
 
         schur0->mat_zero_entries();
         schur0->rhs_zero_entries();
@@ -231,7 +231,7 @@ void RichardsLMH::assembly_linear_system()
             balance_->start_mass_assembly(water_balance_idx_);
         }
 
-        assembly_mh_matrix( multidim_assembler ); // fill matrix
+        assembly_mh_matrix(multidim_assembler); // fill matrix
 
         if (balance_ != nullptr) {
             balance_->finish_source_assembly(water_balance_idx_);

--- a/src/la/linsys.hh
+++ b/src/la/linsys.hh
@@ -60,6 +60,7 @@
 #include "input/input_type_forward.hh"
 #include "input/accessors.hh"
 
+#include "local_system.hh"
 
 #include <mpi.h>
 
@@ -345,6 +346,21 @@ public:
         rhs_set_values(nrow, rows, rhs_vals);
     }
 
+    void set_local_system(LocalSystem & local){
+        arma::mat tmp = local.matrix.t();
+//         DBGCOUT(<< "\n" << tmp);
+//         DBGCOUT(<< "row dofs: \n");
+//             for(unsigned int i=0; i< local.row_dofs.size(); i++)
+//                 cout << local.row_dofs[i] << " ";
+//             cout <<endl;
+        mat_set_values(local.matrix.n_rows, const_cast<int*>(local.row_dofs.data()),
+                       local.matrix.n_cols, const_cast<int*>(local.col_dofs.data()),
+                       tmp.memptr());
+        
+        rhs_set_values(local.matrix.n_rows, const_cast<int*>(local.row_dofs.data()),
+                       local.rhs.memptr());
+    }
+    
     /**
      * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
      * @p row_dofs - are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system

--- a/src/la/local_system.cc
+++ b/src/la/local_system.cc
@@ -1,0 +1,152 @@
+
+#include "local_system.hh"
+
+#include <armadillo>
+#include "system/global_defs.h"
+
+LocalSystem::LocalSystem(unsigned int nrows, unsigned int ncols)
+: matrix(nrows, ncols), rhs(nrows)
+{
+    reset();
+}
+
+
+void LocalSystem::reset()
+{
+    // zeros in local system
+    matrix.zeros();
+    rhs.zeros();
+    // drop all dirichlet values
+    loc_solution_rows.clear();
+    loc_solution.clear();
+    // reset global degrees of freedom vectors
+    row_dofs.resize(matrix.n_rows,0);
+    col_dofs.resize(matrix.n_cols,0);
+}
+
+
+void LocalSystem::set_solution(unsigned int loc_row, double solution)
+{
+    ASSERT_DBG(loc_row < matrix.n_rows);
+    loc_solution_rows.push_back(loc_row);
+    loc_solution.push_back(solution);
+}
+
+
+void LocalSystem::fix_diagonal()
+{
+    // correction of dirichlet diagonal entry
+    for(auto& sol_row : loc_solution_rows)
+        for(unsigned int col = 0; col < matrix.n_cols; col++) {
+//                     DBGCOUT(<< "row " << row_dofs[sol_row] << "  col " << col_dofs[col] << "\n");
+            // look for diagonal entry
+            if (row_dofs[sol_row] == col_dofs[col]) {
+//                                 DBGCOUT(<< "lrow=" << l_row << " lcol=" << l_col << "\n");
+                double new_diagonal = fabs(matrix(sol_row,col));
+                if (new_diagonal == 0.0) {
+                    if (matrix.is_square()) {
+                        new_diagonal = arma::sum( abs(matrix.diag())) / matrix.n_rows;
+                    } else {
+                        new_diagonal = arma::accu( abs(matrix) ) / matrix.n_elem;
+                    }
+                }
+                matrix(sol_row,col) = new_diagonal;
+                rhs(sol_row) = new_diagonal * loc_solution[sol_row];
+            }
+        }
+}
+        
+void LocalSystem::set_value(unsigned int row_dof, unsigned int col_dof,
+                            double mat_val, double rhs_val)
+{
+//             DBGCOUT(<< "row " << row_dof << "  col " << col_dof << "\n");
+    ASSERT_DBG(row_dof < matrix.n_rows);
+    ASSERT_DBG(col_dof < matrix.n_cols);
+    
+    bool eliminate_row = false;
+    bool eliminate_col = false;
+    
+    double tmp_mat = mat_val;
+    double tmp_rhs = rhs_val;
+    
+    for(auto& sol : loc_solution_rows) {
+        if(sol == row_dof){ eliminate_row = true; }
+        if(sol == col_dof){ eliminate_col = true; }
+    }
+    
+    if(eliminate_col){
+        tmp_mat = 0.0;
+        tmp_rhs -= mat_val * loc_solution[col_dof];
+    }
+    
+    if(! eliminate_row){
+        matrix(row_dof, col_dof) = tmp_mat;
+        rhs(row_dof) = tmp_rhs;
+    }
+}
+
+
+void LocalSystem::set_values(std::vector< int >& row_dofs, std::vector< int >& col_dofs,
+                             const arma::mat& loc_matrix, const arma::vec& loc_rhs,
+                             const arma::vec& row_solution, const arma::vec& col_solution)
+{
+    arma::mat tmp = loc_matrix;
+    arma::vec tmp_rhs = loc_rhs;
+    bool negative_row = false;
+    bool negative_col = false;
+
+//             DBGCOUT(<< "tmp\n" << tmp);
+//             DBGCOUT("lrow\n");
+    for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
+        if (row_dofs[l_row] < 0) {
+            tmp_rhs(l_row)=0.0;
+            tmp.row(l_row).zeros();
+            negative_row=true;
+        }
+
+//             DBGCOUT("lcol\n");
+    for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
+        if (col_dofs[l_col] < 0) {
+            tmp_rhs -= loc_matrix.col(l_col) * col_solution[l_col];
+            tmp.col(l_col).zeros();
+            negative_col=true;
+        }
+        
+//             DBGCOUT("main\n");
+        
+    if (negative_row && negative_col) {
+        // look for diagonal entry
+        for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
+            if (row_dofs[l_row] < 0)
+                for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
+                    if (col_dofs[l_col] < 0 && row_dofs[l_row] == col_dofs[l_col]) {
+//                                 DBGCOUT(<< "lrow=" << l_row << " lcol=" << l_col << "\n");
+                        double new_diagonal = fabs(loc_matrix.at(l_row,l_col));
+                        if (new_diagonal == 0.0) {
+                            if (loc_matrix.is_square()) {
+                                new_diagonal = arma::sum( abs(loc_matrix.diag())) / loc_matrix.n_rows;
+                            } else {
+                                new_diagonal = arma::accu( abs(loc_matrix) ) / loc_matrix.n_elem;
+                            }
+                        }
+//                                 tmp.at(l_col, l_row) = new_diagonal;
+                        tmp.at(l_row, l_col) = new_diagonal;
+                        tmp_rhs(l_row) = new_diagonal * row_solution[l_row];
+                    }
+
+    }
+
+    if (negative_row)
+        for(int &row : row_dofs) row=abs(row);
+
+    if (negative_col)
+        for(int &col : col_dofs) col=abs(col);
+
+    
+//             DBGCOUT( << "row_dofs:\n" << arma::conv_to<arma::uvec>::from(row_dofs));
+//             DBGCOUT( << "matrix:\n" << matrix);
+//             DBGCOUT("set mat and rhs\n");
+//             DBGCOUT(<< "tmp\n" << tmp);
+    matrix.submat(arma::conv_to<arma::uvec>::from(row_dofs), arma::conv_to<arma::uvec>::from(col_dofs)) = tmp;
+    rhs.elem(arma::conv_to<arma::uvec>::from(row_dofs)) = tmp_rhs;
+}

--- a/src/la/local_system.cc
+++ b/src/la/local_system.cc
@@ -56,40 +56,73 @@ void LocalSystem::fix_diagonal()
         }
 }
         
-void LocalSystem::set_value(unsigned int row_dof, unsigned int col_dof,
-                            double mat_val, double rhs_val)
+void LocalSystem::set_value(unsigned int row, unsigned int col, double mat_val, double rhs_val)
 {
 //             DBGCOUT(<< "row " << row_dof << "  col " << col_dof << "\n");
-    ASSERT_DBG(row_dof < matrix.n_rows);
-    ASSERT_DBG(col_dof < matrix.n_cols);
+    ASSERT_DBG(row < matrix.n_rows);
+    ASSERT_DBG(col < matrix.n_cols);
     
     bool eliminate_row = false;
-    bool eliminate_col = false;
     
     double tmp_mat = mat_val;
     double tmp_rhs = rhs_val;
     
     for(auto& sol : loc_solution_rows) {
-        if(sol == row_dof){ eliminate_row = true; }
-        if(sol == col_dof){ eliminate_col = true; }
-    }
-    
-    if(eliminate_col){
-        tmp_mat = 0.0;
-        tmp_rhs -= mat_val * loc_solution[col_dof];
+        if(sol == col){
+            tmp_mat = 0.0;
+            tmp_rhs -= mat_val * loc_solution[col];
+        }
+        if(sol == row){ eliminate_row = true; }
     }
     
     if(! eliminate_row){
-        matrix(row_dof, col_dof) = tmp_mat;
-        rhs(row_dof) = tmp_rhs;
+        matrix(row, col) = tmp_mat;
+        rhs(row) = tmp_rhs;
     }
 }
 
 
-void LocalSystem::set_values(std::vector< int >& row_dofs, std::vector< int >& col_dofs,
+void LocalSystem::set_values(std::vector< unsigned int >& rows, std::vector< unsigned int >& cols,
+                             const arma::mat& loc_matrix, const arma::vec& loc_rhs)
+{
+    ASSERT_DBG(loc_matrix.n_rows <= matrix.n_rows);
+    ASSERT_DBG(loc_matrix.n_cols <= matrix.n_cols);
+    
+    bool eliminate_row = false;
+    
+    arma::mat tmp_mat = loc_matrix;
+    arma::vec tmp_rhs = loc_rhs;
+    
+//     DBGCOUT("lrow\n");
+    for(auto& sol : loc_solution_rows)
+        for(unsigned int l_row = 0; l_row < rows.size(); l_row++)
+            if (rows[l_row] == sol) {
+                tmp_rhs(l_row) = 0.0;
+                tmp_mat.row(l_row).zeros();
+            }
+    
+//     DBGCOUT("lcol\n");
+    for(auto& sol : loc_solution_rows)
+        for(unsigned int l_col = 0; l_col < cols.size(); l_col++)
+            if (cols[l_col] == sol) {
+                tmp_rhs -= loc_matrix.col(l_col) * loc_solution[sol];
+                tmp_mat.col(l_col).zeros();
+            }
+    
+//     DBGCOUT("set mat and rhs\n");
+//     DBGCOUT(<< "tmp\n" << tmp_mat);
+    matrix.submat(arma::conv_to<arma::uvec>::from(rows), arma::conv_to<arma::uvec>::from(cols)) = tmp_mat;
+    rhs.elem(arma::conv_to<arma::uvec>::from(rows)) = tmp_rhs;
+}
+
+
+void LocalSystem::set_values(std::vector< int >& rows, std::vector< int >& cols,
                              const arma::mat& loc_matrix, const arma::vec& loc_rhs,
                              const arma::vec& row_solution, const arma::vec& col_solution)
 {
+    ASSERT_DBG(loc_matrix.n_rows <= matrix.n_rows);
+    ASSERT_DBG(loc_matrix.n_cols <= matrix.n_cols);
+    
     arma::mat tmp = loc_matrix;
     arma::vec tmp_rhs = loc_rhs;
     bool negative_row = false;
@@ -97,16 +130,16 @@ void LocalSystem::set_values(std::vector< int >& row_dofs, std::vector< int >& c
 
 //             DBGCOUT(<< "tmp\n" << tmp);
 //             DBGCOUT("lrow\n");
-    for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
-        if (row_dofs[l_row] < 0) {
+    for(unsigned int l_row = 0; l_row < rows.size(); l_row++)
+        if (rows[l_row] < 0) {
             tmp_rhs(l_row)=0.0;
             tmp.row(l_row).zeros();
             negative_row=true;
         }
 
 //             DBGCOUT("lcol\n");
-    for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
-        if (col_dofs[l_col] < 0) {
+    for(unsigned int l_col = 0; l_col < cols.size(); l_col++)
+        if (cols[l_col] < 0) {
             tmp_rhs -= loc_matrix.col(l_col) * col_solution[l_col];
             tmp.col(l_col).zeros();
             negative_col=true;
@@ -116,10 +149,10 @@ void LocalSystem::set_values(std::vector< int >& row_dofs, std::vector< int >& c
         
     if (negative_row && negative_col) {
         // look for diagonal entry
-        for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
-            if (row_dofs[l_row] < 0)
-                for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
-                    if (col_dofs[l_col] < 0 && row_dofs[l_row] == col_dofs[l_col]) {
+        for(unsigned int l_row = 0; l_row < rows.size(); l_row++)
+            if (rows[l_row] < 0)
+                for(unsigned int l_col = 0; l_col < cols.size(); l_col++)
+                    if (cols[l_col] < 0 && row_dofs[-rows[l_row]] == col_dofs[-cols[l_col]]) {
 //                                 DBGCOUT(<< "lrow=" << l_row << " lcol=" << l_col << "\n");
                         double new_diagonal = fabs(loc_matrix.at(l_row,l_col));
                         if (new_diagonal == 0.0) {
@@ -137,16 +170,16 @@ void LocalSystem::set_values(std::vector< int >& row_dofs, std::vector< int >& c
     }
 
     if (negative_row)
-        for(int &row : row_dofs) row=abs(row);
+        for(int &row : rows) row=abs(row);
 
     if (negative_col)
-        for(int &col : col_dofs) col=abs(col);
+        for(int &col : cols) col=abs(col);
 
     
 //             DBGCOUT( << "row_dofs:\n" << arma::conv_to<arma::uvec>::from(row_dofs));
 //             DBGCOUT( << "matrix:\n" << matrix);
 //             DBGCOUT("set mat and rhs\n");
 //             DBGCOUT(<< "tmp\n" << tmp);
-    matrix.submat(arma::conv_to<arma::uvec>::from(row_dofs), arma::conv_to<arma::uvec>::from(col_dofs)) = tmp;
-    rhs.elem(arma::conv_to<arma::uvec>::from(row_dofs)) = tmp_rhs;
+    matrix.submat(arma::conv_to<arma::uvec>::from(rows), arma::conv_to<arma::uvec>::from(cols)) = tmp;
+    rhs.elem(arma::conv_to<arma::uvec>::from(rows)) = tmp_rhs;
 }

--- a/src/la/local_system.cc
+++ b/src/la/local_system.cc
@@ -36,12 +36,13 @@ void LocalSystem::set_solution(unsigned int loc_row, double solution)
 void LocalSystem::fix_diagonal()
 {
     // correction of dirichlet diagonal entry
-    for(auto& sol_row : loc_solution_rows)
+    for(unsigned int i=0; i < loc_solution_rows.size(); i++){
+        unsigned int sol_row = loc_solution_rows[i];
         for(unsigned int col = 0; col < matrix.n_cols; col++) {
 //                     DBGCOUT(<< "row " << row_dofs[sol_row] << "  col " << col_dofs[col] << "\n");
             // look for diagonal entry
             if (row_dofs[sol_row] == col_dofs[col]) {
-//                                 DBGCOUT(<< "lrow=" << l_row << " lcol=" << l_col << "\n");
+//                 DBGCOUT(<< "sol_row=" << sol_row << " col=" << col << " v=" << loc_solution[i] << "\n");
                 double new_diagonal = fabs(matrix(sol_row,col));
                 if (new_diagonal == 0.0) {
                     if (matrix.is_square()) {
@@ -51,12 +52,98 @@ void LocalSystem::fix_diagonal()
                     }
                 }
                 matrix(sol_row,col) = new_diagonal;
-                rhs(sol_row) = new_diagonal * loc_solution[sol_row];
+                rhs(sol_row) = new_diagonal * loc_solution[i];
             }
         }
+    }
 }
-        
+
+
+// void LocalSystem::set_mat_value(unsigned int row, unsigned int col, double mat_val)
+// {
+//     ASSERT_DBG(row < matrix.n_rows);
+//     ASSERT_DBG(col < matrix.n_cols);
+//     
+//     bool eliminate_row = false;
+//     
+//     double tmp_mat = mat_val;
+//     double tmp_rhs = 0;
+//     
+//     for(unsigned int i=0; i < loc_solution_rows.size(); i++){
+//         if(loc_solution_rows[i] == col){
+//             tmp_mat = 0.0;
+//             tmp_rhs -= mat_val * loc_solution[i];
+//         }
+//         if(loc_solution_rows[i] == row){ eliminate_row = true; }
+//     }
+//     
+//     if(! eliminate_row){
+//         matrix(row, col) = tmp_mat;
+//         rhs(row) += tmp_rhs;
+//     }
+// }
+
+
+void LocalSystem::set_mat_values(const std::vector< unsigned int >& rows, 
+                                 const std::vector< unsigned int >& cols,
+                                 const arma::mat& loc_matrix)
+{
+    ASSERT_DBG(loc_matrix.n_rows <= matrix.n_rows);
+    ASSERT_DBG(loc_matrix.n_cols <= matrix.n_cols);
+    
+    arma::mat tmp_mat = loc_matrix;
+    arma::vec tmp_rhs = arma::zeros<arma::vec>(loc_matrix.n_rows);
+    
+//     DBGCOUT("lrow\n");
+    for(auto& sol : loc_solution_rows)
+        for(unsigned int l_row = 0; l_row < rows.size(); l_row++)
+            if (rows[l_row] == sol) {
+                tmp_mat.row(l_row).zeros();
+            }
+    
+//     DBGCOUT("lcol\n");
+    for(unsigned int i=0; i < loc_solution_rows.size(); i++){
+        for(unsigned int l_col = 0; l_col < cols.size(); l_col++)
+            if (cols[l_col] == loc_solution_rows[i]) {
+                tmp_rhs -= loc_matrix.col(l_col) * loc_solution[i];
+                tmp_mat.col(l_col).zeros();
+            }
+    }
+    
+//     DBGCOUT("set mat and rhs\n");
+//     DBGCOUT(<< "tmp\n" << tmp_mat);
+    matrix.submat(arma::uvec(rows), arma::uvec(cols)) = tmp_mat;
+    rhs.elem(arma::uvec(rows)) += tmp_rhs;
+}
+
+
+
 void LocalSystem::set_value(unsigned int row, unsigned int col, double mat_val, double rhs_val)
+{
+    DBGCOUT(<< "row " << row << "  col " << col << "\n");
+    ASSERT_DBG(row < matrix.n_rows);
+    ASSERT_DBG(col < matrix.n_cols);
+    
+    bool eliminate_row = false;
+    
+    double tmp_mat = mat_val;
+    double tmp_rhs = rhs_val;
+    
+    for(unsigned int i=0; i < loc_solution_rows.size(); i++){
+        if(loc_solution_rows[i] == col){
+            tmp_mat = 0.0;
+            tmp_rhs -= mat_val * loc_solution[i];
+        }
+        if(loc_solution_rows[i] == row){ eliminate_row = true; }
+    }
+    
+    if(! eliminate_row){
+        matrix(row, col) = tmp_mat;
+        rhs(row) = tmp_rhs;
+    }
+}
+
+void LocalSystem::add_value(unsigned int row, unsigned int col, double mat_val, double rhs_val)
 {
 //             DBGCOUT(<< "row " << row_dof << "  col " << col_dof << "\n");
     ASSERT_DBG(row < matrix.n_rows);
@@ -67,28 +154,27 @@ void LocalSystem::set_value(unsigned int row, unsigned int col, double mat_val, 
     double tmp_mat = mat_val;
     double tmp_rhs = rhs_val;
     
-    for(auto& sol : loc_solution_rows) {
-        if(sol == col){
+    for(unsigned int i=0; i < loc_solution_rows.size(); i++){
+        if(loc_solution_rows[i] == col){
             tmp_mat = 0.0;
-            tmp_rhs -= mat_val * loc_solution[col];
+            tmp_rhs -= mat_val * loc_solution[i];
         }
-        if(sol == row){ eliminate_row = true; }
+        if(loc_solution_rows[i] == row){ eliminate_row = true; }
     }
     
     if(! eliminate_row){
-        matrix(row, col) = tmp_mat;
-        rhs(row) = tmp_rhs;
+        matrix(row, col) += tmp_mat;
+        rhs(row) += tmp_rhs;
     }
 }
 
-
-void LocalSystem::set_values(std::vector< unsigned int >& rows, std::vector< unsigned int >& cols,
-                             const arma::mat& loc_matrix, const arma::vec& loc_rhs)
+void LocalSystem::set_values(const std::vector< unsigned int >& rows,
+                             const std::vector< unsigned int >& cols,
+                             const arma::mat& loc_matrix,
+                             const arma::vec& loc_rhs)
 {
     ASSERT_DBG(loc_matrix.n_rows <= matrix.n_rows);
     ASSERT_DBG(loc_matrix.n_cols <= matrix.n_cols);
-    
-    bool eliminate_row = false;
     
     arma::mat tmp_mat = loc_matrix;
     arma::vec tmp_rhs = loc_rhs;
@@ -102,17 +188,18 @@ void LocalSystem::set_values(std::vector< unsigned int >& rows, std::vector< uns
             }
     
 //     DBGCOUT("lcol\n");
-    for(auto& sol : loc_solution_rows)
+    for(unsigned int i=0; i < loc_solution_rows.size(); i++){
         for(unsigned int l_col = 0; l_col < cols.size(); l_col++)
-            if (cols[l_col] == sol) {
-                tmp_rhs -= loc_matrix.col(l_col) * loc_solution[sol];
+            if (cols[l_col] == loc_solution_rows[i]) {
+                tmp_rhs -= loc_matrix.col(l_col) * loc_solution[i];
                 tmp_mat.col(l_col).zeros();
             }
+    }
     
 //     DBGCOUT("set mat and rhs\n");
 //     DBGCOUT(<< "tmp\n" << tmp_mat);
-    matrix.submat(arma::conv_to<arma::uvec>::from(rows), arma::conv_to<arma::uvec>::from(cols)) = tmp_mat;
-    rhs.elem(arma::conv_to<arma::uvec>::from(rows)) = tmp_rhs;
+    matrix.submat(arma::uvec(rows), arma::uvec(cols)) = tmp_mat;
+    rhs.elem(arma::uvec(rows)) = tmp_rhs;
 }
 
 

--- a/src/la/local_system.hh
+++ b/src/la/local_system.hh
@@ -4,6 +4,7 @@
 
 #include <armadillo>
 
+class LinSys;
 
 /** Local system class is meant to be used for local assembly and then pass to global linear system.
  * The key idea is to take care of known solution values (Dirichlet boundary conditions) in a common way.
@@ -18,6 +19,7 @@
  */
 class LocalSystem
 {
+friend class LinSys;
 protected:
     arma::mat matrix;   ///< local system matrix
     arma::vec rhs;      ///< local system RHS
@@ -27,10 +29,10 @@ protected:
     /// vector of solution values at @p loc_solution_rows indices (dirichlet BC)
     std::vector<double> loc_solution;
     
+public:
+    
     std::vector<int> row_dofs;  ///< global row indices
     std::vector<int> col_dofs;  ///< global column indices
-    
-public:
     
     /** @brief Constructor.
      * 
@@ -41,6 +43,9 @@ public:
     
     /// Resets the matrix, RHS, dofs to zero and clears solution settings
     void reset();
+    
+    const arma::mat& get_matrix() {return matrix;}
+    const arma::vec& get_rhs() {return rhs;}
     
     /** @brief Set the position and value of known solution.
      * 
@@ -67,7 +72,38 @@ public:
      * @p rhs_val is RHS entry value
      */
     void set_value(unsigned int row, unsigned int col,
-                    double mat_val, double rhs_val);  
+                   double mat_val, double rhs_val);
+
+    /** @brief Adds a single entry into the local system.
+     * 
+     * Known solution must be set before, so it is eliminated correctly during his call.
+     * @p row is local row index of local system
+     * @p col is local column index of local system
+     * @p mat_val is matrix entry value
+     * @p rhs_val is RHS entry value
+     */
+    void add_value(unsigned int row, unsigned int col,
+                   double mat_val, double rhs_val);
+    
+//     /** @brief Sets a single entry into the local system matrix.
+//      * 
+//      * Known solution must be set before, so it is eliminated correctly during his call.
+//      * @p row is local row index of local system
+//      * @p col is local column index of local system
+//      * @p mat_val is matrix entry value
+//      */
+//     void set_mat_value(unsigned int row, unsigned int col, double mat_val);
+    
+    /** @brief Sets a submatrix and rhs subvector into the local system matrix.
+     * 
+     * Known solution must be set before, so it is eliminated correctly during his call.
+     * @p rows are local row indices of local system
+     * @p cols are local column indices of local system
+     * @p loc_mat is submatrix to be entered
+     */
+    void set_mat_values(const std::vector< unsigned int >& rows,
+                        const std::vector< unsigned int >& cols,
+                        const arma::mat& loc_matrix);
     
     /** @brief Sets a submatrix and rhs subvector into the local system.
      * 
@@ -77,8 +113,10 @@ public:
      * @p loc_mat is submatrix to be entered
      * @p loc_rhs is vector to entered into RHS
      */
-    void set_values(std::vector<unsigned int> &rows, std::vector<unsigned int> &cols,
-                    const arma::mat &loc_matrix, const arma::vec &loc_rhs);
+    void set_values(const std::vector<unsigned int> &rows,
+                    const std::vector<unsigned int> &cols,
+                    const arma::mat &loc_matrix,
+                    const arma::vec &loc_rhs);
     
     /**
      * This is a copy of the set_values method from LinSys. (OBSOLETE)

--- a/src/la/local_system.hh
+++ b/src/la/local_system.hh
@@ -1,0 +1,124 @@
+
+#ifndef LOCAL_SYSTEM_HH_
+#define LOCAL_SYSTEM_HH_
+
+#include <armadillo>
+#include "system/global_defs.h"
+
+class LocalSystem
+    {
+    public:
+        
+        LocalSystem(unsigned int nrows, unsigned int ncols)
+        : matrix(arma::zeros(nrows, ncols)), rhs(arma::zeros(nrows,1))
+        {}
+        
+        void reset(){
+            // zeros in local system
+            matrix.zeros();
+            rhs.zeros();
+            // drop all dirichlet values
+            loc_dirichlet_edge.clear();
+            loc_dirichlet_val.clear();
+            // reset global degrees of freedom vectors
+            row_dofs.resize(row_dofs.size(),0);
+            col_dofs.resize(col_dofs.size(),0);
+        }
+        
+        arma::mat matrix;
+        arma::vec rhs;
+        
+        std::vector<unsigned int> loc_dirichlet_edge;   //rename to dirichlet_indicator
+        std::vector<double> loc_dirichlet_val;
+        
+        std::vector<int> row_dofs;
+        std::vector<int> col_dofs;
+        
+        
+        
+        
+        /**
+        * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
+        * @p row_dofs - are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
+        * @p col_dofs - are global indices of columns of the matrix, and possibly
+        *
+        * Application of Dirichlet conditions:
+        * 1) Rows with negative dofs are set to zero.
+        * 2) Cols with negative dofs are eliminated.
+        * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
+        *    diagonal average.
+        *
+        * Caveats:
+        * - can not set dirichlet condition on zero dof 
+        * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
+        *   for passing local matrices.
+        *
+        */
+        void set_values(std::vector<int> &row_dofs, std::vector<int> &col_dofs,
+                        const arma::mat &loc_matrix, const arma::vec &loc_rhs,
+                        const arma::vec &row_solution, const arma::vec &col_solution)
+
+        {
+            arma::mat tmp = loc_matrix;
+            arma::vec tmp_rhs = loc_rhs;
+            bool negative_row = false;
+            bool negative_col = false;
+
+//             DBGCOUT(<< "tmp\n" << tmp);
+//             DBGCOUT("lrow\n");
+            for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
+                if (row_dofs[l_row] < 0) {
+                    tmp_rhs(l_row)=0.0;
+                    tmp.row(l_row).zeros();
+                    negative_row=true;
+                }
+
+//             DBGCOUT("lcol\n");
+            for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
+                if (col_dofs[l_col] < 0) {
+                    tmp_rhs -= loc_matrix.col(l_col) * col_solution[l_col];
+                    tmp.col(l_col).zeros();
+                    negative_col=true;
+                }
+                
+//             DBGCOUT("main\n");
+                
+            if (negative_row && negative_col) {
+                // look for diagonal entry
+                for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
+                    if (row_dofs[l_row] < 0)
+                        for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
+                            if (col_dofs[l_col] < 0 && row_dofs[l_row] == col_dofs[l_col]) {
+//                                 DBGCOUT(<< "lrow=" << l_row << " lcol=" << l_col << "\n");
+                                double new_diagonal = fabs(loc_matrix.at(l_row,l_col));
+                                if (new_diagonal == 0.0) {
+                                    if (loc_matrix.is_square()) {
+                                        new_diagonal = arma::sum( abs(loc_matrix.diag())) / loc_matrix.n_rows;
+                                    } else {
+                                        new_diagonal = arma::accu( abs(loc_matrix) ) / loc_matrix.n_elem;
+                                    }
+                                }
+//                                 tmp.at(l_col, l_row) = new_diagonal;
+                                tmp.at(l_row, l_col) = new_diagonal;
+                                tmp_rhs(l_row) = new_diagonal * row_solution[l_row];
+                            }
+
+            }
+
+            if (negative_row)
+                for(int &row : row_dofs) row=abs(row);
+
+            if (negative_col)
+                for(int &col : col_dofs) col=abs(col);
+
+            
+//             DBGCOUT( << "row_dofs:\n" << arma::conv_to<arma::uvec>::from(row_dofs));
+//             DBGCOUT( << "matrix:\n" << matrix);
+//             DBGCOUT("set mat and rhs\n");
+//             DBGCOUT(<< "tmp\n" << tmp);
+            matrix.submat(arma::conv_to<arma::uvec>::from(row_dofs), arma::conv_to<arma::uvec>::from(col_dofs)) = tmp;
+            rhs.elem(arma::conv_to<arma::uvec>::from(row_dofs)) = tmp_rhs;
+        }
+    };
+    
+#endif // LOCAL_SYSTEM_HH_

--- a/src/la/local_system.hh
+++ b/src/la/local_system.hh
@@ -3,122 +3,109 @@
 #define LOCAL_SYSTEM_HH_
 
 #include <armadillo>
-#include "system/global_defs.h"
 
+
+/** Local system class is meant to be used for local assembly and then pass to global linear system.
+ * The key idea is to take care of known solution values (Dirichlet boundary conditions) in a common way.
+ * 
+ * Usage the class consists of 3 steps:
+ * 1) create local system, set global DoFs.
+ * 2) set all known values (Dirichlet BC)
+ * 3) set matrix and RHS entries 
+ *    (if the entry is on dirichlet row or column, it is now taken care of)
+ * 4) possibly fix the diagonal entries of the local system, where Dirichlet BC is set
+ * 
+ */
 class LocalSystem
-    {
-    public:
-        
-        LocalSystem(unsigned int nrows, unsigned int ncols)
-        : matrix(arma::zeros(nrows, ncols)), rhs(arma::zeros(nrows,1))
-        {}
-        
-        void reset(){
-            // zeros in local system
-            matrix.zeros();
-            rhs.zeros();
-            // drop all dirichlet values
-            loc_dirichlet_edge.clear();
-            loc_dirichlet_val.clear();
-            // reset global degrees of freedom vectors
-            row_dofs.resize(row_dofs.size(),0);
-            col_dofs.resize(col_dofs.size(),0);
-        }
-        
-        arma::mat matrix;
-        arma::vec rhs;
-        
-        std::vector<unsigned int> loc_dirichlet_edge;   //rename to dirichlet_indicator
-        std::vector<double> loc_dirichlet_val;
-        
-        std::vector<int> row_dofs;
-        std::vector<int> col_dofs;
-        
-        
-        
-        
-        /**
-        * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
-        * @p row_dofs - are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
-        * @p col_dofs - are global indices of columns of the matrix, and possibly
-        *
-        * Application of Dirichlet conditions:
-        * 1) Rows with negative dofs are set to zero.
-        * 2) Cols with negative dofs are eliminated.
-        * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
-        *    diagonal average.
-        *
-        * Caveats:
-        * - can not set dirichlet condition on zero dof 
-        * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
-        *   for passing local matrices.
-        *
-        */
-        void set_values(std::vector<int> &row_dofs, std::vector<int> &col_dofs,
-                        const arma::mat &loc_matrix, const arma::vec &loc_rhs,
-                        const arma::vec &row_solution, const arma::vec &col_solution)
+{
+protected:
+    arma::mat matrix;   ///< local system matrix
+    arma::vec rhs;      ///< local system RHS
+    
+    /// vector of row indices where the solution is set (dirichlet BC)
+    std::vector<unsigned int> loc_solution_rows;
+    /// vector of solution values at @p loc_solution_rows indices (dirichlet BC)
+    std::vector<double> loc_solution;
+    
+    std::vector<int> row_dofs;  ///< global row indices
+    std::vector<int> col_dofs;  ///< global column indices
+    
+public:
+    
+    /** @brief Constructor.
+     * 
+     * @p nrows is number of rows of local system
+     * @p ncols is number of columns of local system
+     */
+    LocalSystem(unsigned int nrows, unsigned int ncols);
+    
+    /// Resets the matrix, RHS, dofs to zero and clears solution settings
+    void reset();
+    
+    /** @brief Set the position and value of known solution.
+     * 
+     * @p loc_row is local row index in solution vector
+     * @p solution is the values of the solutioin
+     */
+    void set_solution(unsigned int loc_row, double solution);
+    
+    /** When the local system is assembled,
+     * the diagonal entries on rows where the solution is set might be zero.
+     * Therefore it is necessary to set a proper value to the diagonal entry
+     * and respective RHS entry, such that the given solution holds.
+     * 
+     * Call only when the assembly of local system is finished.
+     */
+    void fix_diagonal();
 
-        {
-            arma::mat tmp = loc_matrix;
-            arma::vec tmp_rhs = loc_rhs;
-            bool negative_row = false;
-            bool negative_col = false;
-
-//             DBGCOUT(<< "tmp\n" << tmp);
-//             DBGCOUT("lrow\n");
-            for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
-                if (row_dofs[l_row] < 0) {
-                    tmp_rhs(l_row)=0.0;
-                    tmp.row(l_row).zeros();
-                    negative_row=true;
-                }
-
-//             DBGCOUT("lcol\n");
-            for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
-                if (col_dofs[l_col] < 0) {
-                    tmp_rhs -= loc_matrix.col(l_col) * col_solution[l_col];
-                    tmp.col(l_col).zeros();
-                    negative_col=true;
-                }
-                
-//             DBGCOUT("main\n");
-                
-            if (negative_row && negative_col) {
-                // look for diagonal entry
-                for(unsigned int l_row = 0; l_row < row_dofs.size(); l_row++)
-                    if (row_dofs[l_row] < 0)
-                        for(unsigned int l_col = 0; l_col < col_dofs.size(); l_col++)
-                            if (col_dofs[l_col] < 0 && row_dofs[l_row] == col_dofs[l_col]) {
-//                                 DBGCOUT(<< "lrow=" << l_row << " lcol=" << l_col << "\n");
-                                double new_diagonal = fabs(loc_matrix.at(l_row,l_col));
-                                if (new_diagonal == 0.0) {
-                                    if (loc_matrix.is_square()) {
-                                        new_diagonal = arma::sum( abs(loc_matrix.diag())) / loc_matrix.n_rows;
-                                    } else {
-                                        new_diagonal = arma::accu( abs(loc_matrix) ) / loc_matrix.n_elem;
-                                    }
-                                }
-//                                 tmp.at(l_col, l_row) = new_diagonal;
-                                tmp.at(l_row, l_col) = new_diagonal;
-                                tmp_rhs(l_row) = new_diagonal * row_solution[l_row];
-                            }
-
-            }
-
-            if (negative_row)
-                for(int &row : row_dofs) row=abs(row);
-
-            if (negative_col)
-                for(int &col : col_dofs) col=abs(col);
-
-            
-//             DBGCOUT( << "row_dofs:\n" << arma::conv_to<arma::uvec>::from(row_dofs));
-//             DBGCOUT( << "matrix:\n" << matrix);
-//             DBGCOUT("set mat and rhs\n");
-//             DBGCOUT(<< "tmp\n" << tmp);
-            matrix.submat(arma::conv_to<arma::uvec>::from(row_dofs), arma::conv_to<arma::uvec>::from(col_dofs)) = tmp;
-            rhs.elem(arma::conv_to<arma::uvec>::from(row_dofs)) = tmp_rhs;
-        }
-    };
+    /**
+    * This is a copy of the set_values method from LinSys.
+    * 
+    * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
+    * @p row_dofs - are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
+    * @p col_dofs - are global indices of columns of the matrix, and possibly
+    *
+    * Application of Dirichlet conditions:
+    * 1) Rows with negative dofs are set to zero.
+    * 2) Cols with negative dofs are eliminated.
+    * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
+    *    diagonal average.
+    *
+    * Caveats:
+    * - can not set dirichlet condition on zero dof 
+    * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
+    *   for passing local matrices.
+    *
+    */
+    void set_value(unsigned int row_dof, unsigned int col_dof,
+                    double mat_val, double rhs_val);        
+    
+    /**
+        * This is a copy of the set_values method from LinSys.
+        * 
+    * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
+    * @p row_dofs are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
+    * @p col_dofs are global indices of columns of the matrix
+    * @p loc_matrix is local matrix which is to be set in the local system
+    * @p loc_rhs is local rhs which is to be set in the local system
+    * @p row_solution are values of dofs belonging to row_dofs
+    * @p col_solution are values of dofs belonging to col_dofs
+    *
+    * Application of Dirichlet conditions:
+    * 1) Rows with negative dofs are set to zero.
+    * 2) Cols with negative dofs are eliminated.
+    * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
+    *    diagonal average.
+    *
+    * Caveats:
+    * - can not set dirichlet condition on zero dof 
+    * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
+    *   for passing local matrices into LinSys.
+    *
+    */
+    void set_values(std::vector<int> &row_dofs, std::vector<int> &col_dofs,
+                    const arma::mat &loc_matrix, const arma::vec &loc_rhs,
+                    const arma::vec &row_solution, const arma::vec &col_solution);
+};
     
 #endif // LOCAL_SYSTEM_HH_

--- a/src/la/local_system.hh
+++ b/src/la/local_system.hh
@@ -50,7 +50,7 @@ public:
     void set_solution(unsigned int loc_row, double solution);
     
     /** When the local system is assembled,
-     * the diagonal entries on rows where the solution is set might be zero.
+     * the diagonal entries on rows, where the solution is set, might be zero.
      * Therefore it is necessary to set a proper value to the diagonal entry
      * and respective RHS entry, such that the given solution holds.
      * 
@@ -58,52 +58,52 @@ public:
      */
     void fix_diagonal();
 
-    /**
-    * This is a copy of the set_values method from LinSys.
-    * 
-    * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
-    * @p row_dofs - are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
-    * @p col_dofs - are global indices of columns of the matrix, and possibly
-    *
-    * Application of Dirichlet conditions:
-    * 1) Rows with negative dofs are set to zero.
-    * 2) Cols with negative dofs are eliminated.
-    * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
-    *    diagonal average.
-    *
-    * Caveats:
-    * - can not set dirichlet condition on zero dof 
-    * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
-    *   for passing local matrices.
-    *
-    */
-    void set_value(unsigned int row_dof, unsigned int col_dof,
-                    double mat_val, double rhs_val);        
+    /** @brief Sets a single entry into the local system.
+     * 
+     * Known solution must be set before, so it is eliminated correctly during his call.
+     * @p row is local row index of local system
+     * @p col is local column index of local system
+     * @p mat_val is matrix entry value
+     * @p rhs_val is RHS entry value
+     */
+    void set_value(unsigned int row, unsigned int col,
+                    double mat_val, double rhs_val);  
+    
+    /** @brief Sets a submatrix and rhs subvector into the local system.
+     * 
+     * Known solution must be set before, so it is eliminated correctly during his call.
+     * @p rows are local row indices of local system
+     * @p cols are local column indices of local system
+     * @p loc_mat is submatrix to be entered
+     * @p loc_rhs is vector to entered into RHS
+     */
+    void set_values(std::vector<unsigned int> &rows, std::vector<unsigned int> &cols,
+                    const arma::mat &loc_matrix, const arma::vec &loc_rhs);
     
     /**
-        * This is a copy of the set_values method from LinSys.
-        * 
-    * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
-    * @p row_dofs are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
-    * @p col_dofs are global indices of columns of the matrix
-    * @p loc_matrix is local matrix which is to be set in the local system
-    * @p loc_rhs is local rhs which is to be set in the local system
-    * @p row_solution are values of dofs belonging to row_dofs
-    * @p col_solution are values of dofs belonging to col_dofs
-    *
-    * Application of Dirichlet conditions:
-    * 1) Rows with negative dofs are set to zero.
-    * 2) Cols with negative dofs are eliminated.
-    * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
-    *    diagonal average.
-    *
-    * Caveats:
-    * - can not set dirichlet condition on zero dof 
-    * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
-    *   for passing local matrices into LinSys.
-    *
-    */
-    void set_values(std::vector<int> &row_dofs, std::vector<int> &col_dofs,
+     * This is a copy of the set_values method from LinSys. (OBSOLETE)
+     * 
+     * Shortcut to assembly into matrix and RHS in one call, possibly apply Dirichlet boundary conditions.
+     * @p row_dofs are global indices of rows of dense @p matrix and rows of dense vector @rhs in global system
+     * @p col_dofs are global indices of columns of the matrix
+     * @p loc_matrix is local matrix which is to be set in the local system
+     * @p loc_rhs is local rhs which is to be set in the local system
+     * @p row_solution are values of dofs belonging to row_dofs
+     * @p col_solution are values of dofs belonging to col_dofs
+     *
+     * Application of Dirichlet conditions:
+     * 1) Rows with negative dofs are set to zero.
+     * 2) Cols with negative dofs are eliminated.
+     * 3) If there are entries on global diagonal. We determine value K either from diagonal of local matrix, or (if it is zero) from
+     *    diagonal average.
+     *
+     * Caveats:
+     * - can not set dirichlet condition on zero dof 
+     * - Armadillo stores matrix in column first form (Fortran like) which makes it not well suited 
+     *   for passing local matrices into LinSys.
+     *
+     */
+    void set_values(std::vector<int> &rows, std::vector<int> &cols,
                     const arma::mat &loc_matrix, const arma::vec &loc_rhs,
                     const arma::vec &row_solution, const arma::vec &col_solution);
 };

--- a/unit_tests/la/CMakeLists.txt
+++ b/unit_tests/la/CMakeLists.txt
@@ -28,6 +28,7 @@ set(libs la_lib system_lib)
 add_test_directory("${libs}")
 
 define_mpi_test(linsys 1)
+define_test(local_system)
 
 define_mpi_test(schur_compl 1)
 define_mpi_test(schur_compl 2)

--- a/unit_tests/la/local_system_test.cpp
+++ b/unit_tests/la/local_system_test.cpp
@@ -54,63 +54,75 @@ public:
             
     }
     
+    void edit_full_matrix(arma::uvec rows, arma::uvec cols, arma::mat& loc_mat, arma::vec& loc_rhs){
+        loc_mat=arma::randu<arma::mat>(rows.size(), cols.size());
+        loc_rhs=arma::randu<arma::vec>(rows.size());
+        // apply to full system
+        full_matrix_.submat(rows, cols)+=loc_mat;
+        full_rhs_.elem(rows)+=loc_rhs;
+            
+//         cout << "full_matrix\n" << full_matrix_;
+//         cout << "full_rhs\n" << full_rhs_;
+    }
+    
+    void check_result()
+    {
+        
+        // zero dirichlet rows and cols
+//         cout << "Dirich rows:\n" << dirichlet_rows_;
+//         cout << "matrix_:\n" << matrix;
+        
+        // check consistency
+        double eps=4*arma::datum::eps;
+        
+        EXPECT_TRUE( arma::norm(matrix.submat(dirichlet_rows_, non_dirichlet_rows_), "inf") < eps);
+            
+        EXPECT_TRUE( arma::norm(matrix.submat(non_dirichlet_rows_, dirichlet_rows_), "inf") < eps);
+        
+        auto dirich_submat = matrix.submat(dirichlet_rows_, dirichlet_rows_);
+        EXPECT_TRUE( arma::norm( dirich_submat - arma::diagmat(dirich_submat), "inf") < eps );
+        
+        /*
+        // full check
+        arma::mat reduced_mat=full_matrix_;
+        auto dirich_cols=reduced_matrix_.submat(arma::span::all, dirichlet_rows_);
+        arma::vec reduced_rhs_=full_rhs_ - dirich_cols *dirichlet_values_;
+        dirich_cols.zeros();
+        
+        reduced_matrix_.submat(dirichlet_rows_, arma::span::all).zeros();
+        reduced_matrix_.submat(dirichlet_rows_, dirichlet_rows_) = dirich_submat;
+        reduced_rhs_.subvec(dirichlet_rows_)=dirich_submat*dirichlet_values_;
+        
+        EXPECT_TRUE( arma::all( abs(matrix_ - reduced_matrix_)<eps ) );
+        EXPECT_TRUE( arma::all( abs(rhs_ - reduced_rhs_)<eps ) );
+        */
+    }
+    
     /**
          * Add a random local matrix and rhs spanning over given rows and columns.
          * 
          */
     void add(arma::uvec rows, arma::uvec cols) {
         
-            arma::mat loc_mat=arma::randu<arma::mat>(rows.size(), cols.size());
-            arma::vec loc_rhs=arma::randu<arma::vec>(rows.size());
-            // apply to full system
-            full_matrix_.submat(rows, cols)+=loc_mat;
-            full_rhs_.elem(rows)+=loc_rhs;
-            
-//             cout << "full_matrix\n" << full_matrix_;
-//             cout << "full_rhs\n" << full_rhs_;
-            
-            // apply to fixture system
-            arma::vec row_sol=dirichlet_values_.elem(rows);
-            arma::vec col_sol=dirichlet_values_.elem(cols);
-            
-            
-            auto i_rows=arma::conv_to<std::vector<int> >::from(
-                          arma::conv_to<arma::ivec>::from(rows)%dirichlet_.elem(rows));
-            auto i_cols=arma::conv_to<std::vector<int> >::from(
-                          arma::conv_to<arma::ivec>::from(cols)%dirichlet_.elem(cols));
-            
-//             cout << "i_rows\n" << arma::ivec(i_rows);
-//             cout << "i_cols\n" << arma::ivec(i_cols);
-            this->set_values(i_rows, i_cols, loc_mat, loc_rhs, row_sol, col_sol);            
-            
-
-            // check consistency
-            double eps=4*arma::datum::eps;
-            // zero dirichlet rows and cols
-//             cout << "Dirich rows:\n" << dirichlet_rows_;
-//             cout << "matrix_:\n" << matrix;
-            
-            EXPECT_TRUE( arma::norm(matrix.submat(dirichlet_rows_, non_dirichlet_rows_), "inf") < eps);
-            
-            EXPECT_TRUE( arma::norm(matrix.submat(non_dirichlet_rows_, dirichlet_rows_), "inf") < eps);
-            
-            auto dirich_submat = matrix.submat(dirichlet_rows_, dirichlet_rows_);
-            EXPECT_TRUE( arma::norm( dirich_submat - arma::diagmat(dirich_submat), "inf") < eps );
-            
-            /*
-            // full check
-            arma::mat reduced_mat=full_matrix_;
-            auto dirich_cols=reduced_matrix_.submat(arma::span::all, dirichlet_rows_);
-            arma::vec reduced_rhs_=full_rhs_ - dirich_cols *dirichlet_values_;
-            dirich_cols.zeros();
-            
-            reduced_matrix_.submat(dirichlet_rows_, arma::span::all).zeros();
-            reduced_matrix_.submat(dirichlet_rows_, dirichlet_rows_) = dirich_submat;
-            reduced_rhs_.subvec(dirichlet_rows_)=dirich_submat*dirichlet_values_;
-            
-            EXPECT_TRUE( arma::all( abs(matrix_ - reduced_matrix_)<eps ) );
-            EXPECT_TRUE( arma::all( abs(rhs_ - reduced_rhs_)<eps ) );
-            */
+        arma::mat loc_mat;
+        arma::vec loc_rhs;
+        edit_full_matrix(rows,cols, loc_mat, loc_rhs);
+        
+        // apply to fixture system
+        arma::vec row_sol=dirichlet_values_.elem(rows);
+        arma::vec col_sol=dirichlet_values_.elem(cols);
+        
+        
+        auto i_rows=arma::conv_to<std::vector<int> >::from(
+                        arma::conv_to<arma::ivec>::from(rows)%dirichlet_.elem(rows));
+        auto i_cols=arma::conv_to<std::vector<int> >::from(
+                        arma::conv_to<arma::ivec>::from(cols)%dirichlet_.elem(cols));
+        
+//         cout << "i_rows\n" << arma::ivec(i_rows);
+//         cout << "i_cols\n" << arma::ivec(i_cols);
+        this->set_values(i_rows, i_cols, loc_mat, loc_rhs, row_sol, col_sol);            
+        
+        check_result();
     }
     
     /**
@@ -118,52 +130,59 @@ public:
          * 
          */
     void add_single(arma::uvec rows, arma::uvec cols) {
-          
-            arma::mat loc_mat=arma::randu<arma::mat>(rows.size(), cols.size());
-            arma::vec loc_rhs=arma::randu<arma::vec>(rows.size());
-            // apply to full system
-            full_matrix_.submat(rows, cols)+=loc_mat;
-            full_rhs_.elem(rows)+=loc_rhs;
+        
+        arma::mat loc_mat;
+        arma::vec loc_rhs;
+        edit_full_matrix(rows,cols, loc_mat, loc_rhs);
             
-//             cout << "full_matrix\n" << full_matrix_;
-//             cout << "full_rhs\n" << full_rhs_;
-            
-//             // apply to fixture system
-//             arma::vec row_sol=dirichlet_values_.elem(rows);
-//             arma::vec col_sol=dirichlet_values_.elem(cols);
-//             
-//             
-//             auto i_rows=arma::conv_to<std::vector<int> >::from(
-//                           arma::conv_to<arma::ivec>::from(rows)%dirichlet_.elem(rows));
-//             auto i_cols=arma::conv_to<std::vector<int> >::from(
-//                           arma::conv_to<arma::ivec>::from(cols)%dirichlet_.elem(cols));
-            
-            // set dirichlet
-            for(unsigned int i=0; i < dirichlet_rows_.n_elem; i++){
-//                 cout << "set solution: " << dirichlet_rows_(i) << "  " << dirichlet_values_(dirichlet_rows_(i)) << endl;
-                set_solution(dirichlet_rows_(i), dirichlet_values_(dirichlet_rows_(i)));
-            }
-            
-//             cout << "i_rows\n" << arma::ivec(i_rows);
-//             cout << "i_cols\n" << arma::ivec(i_cols);
-            for(unsigned int i=0; i < rows.n_elem; i++)
-                for(unsigned int j=0; j < cols.n_elem; j++)
-                    this->set_value(rows(i), cols(j), loc_mat(i,j), loc_rhs(i));
-            
-            fix_diagonal();
-            
-            // check consistency
-            double eps=4*arma::datum::eps;
-            // zero dirichlet rows and cols
-//             cout << "Dirich rows:\n" << dirichlet_rows_;
-//             cout << "matrix_:\n" << matrix;
-            
-            EXPECT_TRUE( arma::norm(matrix.submat(dirichlet_rows_, non_dirichlet_rows_), "inf") < eps);
-            
-            EXPECT_TRUE( arma::norm(matrix.submat(non_dirichlet_rows_, dirichlet_rows_), "inf") < eps);
-            
-            auto dirich_submat = matrix.submat(dirichlet_rows_, dirichlet_rows_);
-            EXPECT_TRUE( arma::norm( dirich_submat - arma::diagmat(dirich_submat), "inf") < eps );
+        // set dirichlet
+        for(unsigned int i=0; i < dirichlet_rows_.n_elem; i++){
+//             cout << "set solution: " << dirichlet_rows_(i) << "  " << dirichlet_values_(dirichlet_rows_(i)) << endl;
+            this->set_solution(dirichlet_rows_(i), dirichlet_values_(dirichlet_rows_(i)));
+        }
+        
+        // set entries
+        for(unsigned int i=0; i < rows.n_elem; i++)
+            for(unsigned int j=0; j < cols.n_elem; j++)
+                this->set_value(rows(i), cols(j), loc_mat(i,j), loc_rhs(i));
+        
+        this->fix_diagonal();
+        
+        check_result();
+    }
+    
+        /**
+         * Add a random local matrix and rhs spanning over given rows and columns.
+         * 
+         */
+    void add_subsystem(arma::uvec rows, arma::uvec cols) {
+        
+        arma::mat loc_mat;
+        arma::vec loc_rhs;
+        edit_full_matrix(rows,cols, loc_mat, loc_rhs);
+        
+//         auto i_rows=arma::conv_to<std::vector<int> >::from(
+//                         arma::conv_to<arma::ivec>::from(rows)%dirichlet_.elem(rows));
+//         auto i_cols=arma::conv_to<std::vector<int> >::from(
+//                         arma::conv_to<arma::ivec>::from(cols)%dirichlet_.elem(cols));
+        
+        auto i_rows = arma::conv_to<std::vector<unsigned int>>::from(rows);
+        auto i_cols = arma::conv_to<std::vector<unsigned int>>::from(cols);
+//         cout << "i_rows\n" << arma::ivec(i_rows);
+//         cout << "i_cols\n" << arma::ivec(i_cols);
+        
+        
+        // set dirichlet
+        for(unsigned int i=0; i < dirichlet_rows_.n_elem; i++){
+//             cout << "set solution: " << dirichlet_rows_(i) << "  " << dirichlet_values_(dirichlet_rows_(i)) << endl;
+            this->set_solution(dirichlet_rows_(i), dirichlet_values_(dirichlet_rows_(i)));
+        }
+        
+        this->set_values(i_rows, i_cols, loc_mat, loc_rhs); 
+        
+        this->fix_diagonal();
+        
+        check_result();
     }
 
     
@@ -186,30 +205,47 @@ TEST_F(SetValues, dirichlet_values) {
     for(unsigned int i=0; i<n; i++) {
 //         cout << "############################################################   " << i << endl;
         restart();
-        this->add( {0,1,2}, {0,1,2} );
-        this->add( {0,1}, {3,4,5} );
-        this->add( {4,5}, {0,1} );
-        this->add( {0,2,3}, {0,2,3} );
-        this->add( {3,4}, {3,4,5} );
-        this->add( {5}, {0,2,4,5} );
-        this->add( {1,3,4}, {4,5} );
-        this->add( {0,3}, {4,5} );
+        add( {0,1,2}, {0,1,2} );
+        add( {0,1}, {3,4,5} );
+        add( {4,5}, {0,1} );
+        add( {0,2,3}, {0,2,3} );
+        add( {3,4}, {3,4,5} );
+        add( {5}, {0,2,4,5} );
+        add( {1,3,4}, {4,5} );
+        add( {0,3}, {4,5} );
     }     
 };
 
-TEST_F(SetValues, dirichlet_value) {
+TEST_F(SetValues, set_value) {
     
     unsigned int n = 100;
     for(unsigned int i=0; i<n; i++) {
 //         cout << "############################################################   " << i << endl;
         restart();
-        this->add_single( {0,1,2}, {0,1,2} );
-        this->add_single( {0,1}, {3,4,5} );
-        this->add_single( {4,5}, {0,1} );
-        this->add_single( {0,2,3}, {0,2,3} );
-        this->add_single( {3,4}, {3,4,5} );
-        this->add_single( {5}, {0,2,4,5} );
-        this->add_single( {1,3,4}, {4,5} );
-        this->add_single( {0,3}, {4,5} );
+        add_single( {0,1,2}, {0,1,2} );
+        add_single( {0,1}, {3,4,5} );
+        add_single( {4,5}, {0,1} );
+        add_single( {0,2,3}, {0,2,3} );
+        add_single( {3,4}, {3,4,5} );
+        add_single( {5}, {0,2,4,5} );
+        add_single( {1,3,4}, {4,5} );
+        add_single( {0,3}, {4,5} );
+    }     
+}; 
+
+TEST_F(SetValues, set_values) {
+    
+    unsigned int n = 100;
+    for(unsigned int i=0; i<n; i++) {
+//         cout << "############################################################   " << i << endl;
+        restart();
+        add_subsystem( {0,1,2}, {0,1,2} );
+        add_subsystem( {0,1}, {3,4,5} );
+        add_subsystem( {4,5}, {0,1} );
+        add_subsystem( {0,2,3}, {0,2,3} );
+        add_subsystem( {3,4}, {3,4,5} );
+        add_subsystem( {5}, {0,2,4,5} );
+        add_subsystem( {1,3,4}, {4,5} );
+        add_subsystem( {0,3}, {4,5} );
     }     
 };

--- a/unit_tests/la/local_system_test.cpp
+++ b/unit_tests/la/local_system_test.cpp
@@ -1,0 +1,138 @@
+/*
+ * local_system_test.cpp
+ *
+ *  Created on: Sep 9, 2014
+ *      Author: pe
+ */
+
+
+
+#include "flow_gtest.hh"
+#include "la/local_system.hh"
+#include <armadillo>
+
+using namespace std;
+
+
+
+class SetValues : public testing::Test, public LocalSystem {
+public:
+    
+    static const unsigned int size = 6;
+    
+    SetValues() : LocalSystem(size,size) {
+    }
+
+    ~SetValues() {
+    }
+
+    /// Test methods
+    /**
+         * Set system size and generate random dirichlet conditions.
+         */
+    void set_size(unsigned int size) {
+            full_matrix_ = matrix = arma::zeros(size, size);
+            full_rhs_    = rhs    = arma::zeros(size);
+            
+            dirichlet_rows_ = arma::find(arma::randu<arma::vec>(size)<0.2);
+            dirichlet_.ones(size);
+            dirichlet_.elem(dirichlet_rows_ ) *= -1;
+            dirichlet_[0]=1;
+            
+            dirichlet_values_=arma::randu<arma::vec>(size);
+            dirichlet_rows_=arma::find(dirichlet_ < 0);
+            non_dirichlet_rows_=arma::find(dirichlet_ > 0);
+            
+//             cout << "dir_rows\n" << dirichlet_rows_;
+//             cout << "dir\n" << dirichlet_;
+    }
+    
+    /**
+         * Add a random local matrix and rhs spanning over given rows and columns.
+         * 
+         */
+    void add(arma::uvec rows, arma::uvec cols) {
+          
+            arma::mat loc_mat=arma::randu<arma::mat>(rows.size(), cols.size());
+            arma::vec loc_rhs=arma::randu<arma::vec>(rows.size());
+            // apply to full system
+            full_matrix_.submat(rows, cols)+=loc_mat;
+            full_rhs_.elem(rows)+=loc_rhs;
+            
+//             cout << "full_matrix\n" << full_matrix_;
+//             cout << "full_rhs\n" << full_rhs_;
+            
+            // apply to fixture system
+            arma::vec row_sol=dirichlet_values_.elem(rows);
+            arma::vec col_sol=dirichlet_values_.elem(cols);
+            
+            
+            auto i_rows=arma::conv_to<std::vector<int> >::from(
+                          arma::conv_to<arma::ivec>::from(rows)%dirichlet_.elem(rows));
+            auto i_cols=arma::conv_to<std::vector<int> >::from(
+                          arma::conv_to<arma::ivec>::from(cols)%dirichlet_.elem(cols));
+            
+//             cout << "i_rows\n" << arma::ivec(i_rows);
+//             cout << "i_cols\n" << arma::ivec(i_cols);
+            this->set_values(i_rows, i_cols, loc_mat, loc_rhs, row_sol, col_sol);            
+            
+
+            // check consistency
+            double eps=4*arma::datum::eps;
+            // zero dirichlet rows and cols
+//             cout << "Dirich rows:\n" << dirichlet_rows_;
+//             cout << "matrix_:\n" << matrix;
+            
+            EXPECT_TRUE( arma::norm(matrix.submat(dirichlet_rows_, non_dirichlet_rows_), "inf") < eps);
+            
+            EXPECT_TRUE( arma::norm(matrix.submat(non_dirichlet_rows_, dirichlet_rows_), "inf") < eps);
+            
+            auto dirich_submat = matrix.submat(dirichlet_rows_, dirichlet_rows_);
+            EXPECT_TRUE( arma::norm( dirich_submat - arma::diagmat(dirich_submat), "inf") < eps );
+            
+            /*
+            // full check
+            arma::mat reduced_mat=full_matrix_;
+            auto dirich_cols=reduced_matrix_.submat(arma::span::all, dirichlet_rows_);
+            arma::vec reduced_rhs_=full_rhs_ - dirich_cols *dirichlet_values_;
+            dirich_cols.zeros();
+            
+            reduced_matrix_.submat(dirichlet_rows_, arma::span::all).zeros();
+            reduced_matrix_.submat(dirichlet_rows_, dirichlet_rows_) = dirich_submat;
+            reduced_rhs_.subvec(dirichlet_rows_)=dirich_submat*dirichlet_values_;
+            
+            EXPECT_TRUE( arma::all( abs(matrix_ - reduced_matrix_)<eps ) );
+            EXPECT_TRUE( arma::all( abs(rhs_ - reduced_rhs_)<eps ) );
+            */
+    }
+
+    
+    arma::uvec non_dirichlet_rows_;
+    arma::uvec dirichlet_rows_;
+    arma::ivec dirichlet_;
+    arma::vec dirichlet_values_;
+        
+    arma::mat full_matrix_;
+    arma::vec full_rhs_;
+};
+
+
+
+
+
+TEST_F(SetValues, dirichlet) {
+    
+    unsigned int n = 100;
+    for(unsigned int i=0; i<n; i++) {
+//         cout << "############################################################   " << i << endl;
+        this->set_size(6);
+        this->add( {0,1,2}, {0,1,2} );
+        this->add( {0,1}, {3,4,5} );
+        this->add( {4,5}, {0,1} );
+        this->add( {0,2,3}, {0,2,3} );
+        this->add( {3,4}, {3,4,5} );
+        this->add( {5}, {0,2,4,5} );
+        this->add( {1,3,4}, {4,5} );
+        this->add( {0,3}, {4,5,} );
+    }     
+};


### PR DESCRIPTION
Suggestion of new assembly in Darcy Flow.

problems:
- preallocation is done by the assembly functions - hard to read and debug..
- new LocalSystem is dense at the moment - since we write it whole into linsys,
  more entries with zeros are added.
- test03 - test_output.yaml - the results are different in order of rounding errors, where the error in observe points comes from, since the numbers are the same...
- test 11,12 with simple 3tetra meshes with Dirichlet BC have errors in preallocation
  (when not calling schur_allocation in darcy_assembler, computation on 1 proc. works, but on more it gets stuck on balance->start**\* functions, I do not understand)
- test10 - richards_lmh.yaml - there is only total flux bc in contrast to the other test, but I failed to find a problem... (the solution is constant in time..)
- test01 - bddc test gets stuck on more than 1 proc.; I do not known why
