### PR TITLE
Fix TOS::zero_time_step() for correct balance output.

### DIFF
--- a/src/transport/transport_operator_splitting.cc
+++ b/src/transport/transport_operator_splitting.cc
@@ -258,8 +258,7 @@ void TransportOperatorSplitting::zero_time_step()
     //DebugOut() << "tos ZERO TIME STEP.\n";
     convection->zero_time_step();
     if(reaction) reaction->zero_time_step();
-    convection->output_stream()->write_time_frame();
-    if (balance_ != nullptr) balance_->output(time_->t());
+    output_data();
 
 }
 


### PR DESCRIPTION
Method did not check if balance output has to be done at initial time. Fix #726.