### PR TITLE
JHy - change arg logic within runtest script

### DIFF
--- a/src/python/scripts/yamlc/yaml_config.py
+++ b/src/python/scripts/yamlc/yaml_config.py
@@ -123,13 +123,18 @@ class ConfigBase(object):
     """
     Class ConfigBase represents single configuration yaml file
     """
-
-    def __init__(self, yaml_config_file):
+    # dummy cases will be generated
+    MISSING_POLICY_CREATE_DEFAULT   = 1
+    # files not specified in config.yaml will not be executed
+    MISSING_POLICY_IGNORE           = 2
+    
+    def __init__(self, yaml_config_file, missing_policy=MISSING_POLICY_CREATE_DEFAULT):
         self.yaml_config_file = yaml_config_file
         self.root = Paths.dirname(self.yaml_config_file)
         self.yamls = self._get_all_yamls()
         self.cases = list()
         self.common_config = None
+        self.missing_policy = missing_policy
 
         # create dummy case for every yaml file in folder
         if not Paths.exists(self.yaml_config_file):
@@ -163,10 +168,11 @@ class ConfigBase(object):
                         missing.remove(f)
 
             # process rest (dummy case)
-            for y in missing:
-                dummy_case = deepcopy(self.common_config)
-                dummy_case[yamlc.TAG_FILES] = [y]
-                self.cases.append(dummy_case)
+            if missing_policy == self.MISSING_POLICY_CREATE_DEFAULT:
+                for y in missing:
+                    dummy_case = deepcopy(self.common_config)
+                    dummy_case[yamlc.TAG_FILES] = [y]
+                    self.cases.append(dummy_case)
 
     def get_all(self):
         """
@@ -308,9 +314,9 @@ class ConfigPool(object):
             return self.add_config(yaml_file)
         return self.add_case(yaml_file)
 
-    def parse(self):
+    def parse(self, missing_policy=ConfigBase.MISSING_POLICY_CREATE_DEFAULT):
         for k, v in list(self.configs.items()):
-            self.configs[k] = ConfigBase(k)
+            self.configs[k] = ConfigBase(k, missing_policy)
 
         for k, v in list(self.files.items()):
             config = Paths.join(Paths.dirname(k), yamlc.CONFIG_YAML)

--- a/src/python/utils/argparser.py
+++ b/src/python/utils/argparser.py
@@ -283,8 +283,10 @@ class Parser(object):
         :rtype: RuntestArgs
         """
         result = RuntestArgs(*parser.parse_known_args(args))
+        
+        # if no paths or location are given, assuming current directory
         if not result.args:
-            parser.error('No yaml files or folder given')
+            result.args = ['.']
 
         cls.on_parse(result)
         return result


### PR DESCRIPTION
Previously:
 - All yaml files contained in the processing folder were executed
   even if no explicit setting was present in config.yaml

Current:
 - Only yaml files which are specified in the config.yaml
   will be executed.

This change only affect runtest script if directories are passed, e.g.:
  `runtest -n 1 tests/10_darcy`

Directly specifying yaml file will ALWAYS execute the test, e.g.:
  `runtest-n 1 tests/10_darcy/01_source.yaml`