### PR TITLE
Implement FETensor and FEVector.

### DIFF
--- a/src/fem/fe_system.hh
+++ b/src/fem/fe_system.hh
@@ -101,18 +101,24 @@ class FESystem : public FiniteElement<dim>
 public:
   
     /**
-     * @brief Constructor. FESystem for vector or tensor created from a scalar FE.
-     * @param fe Base finite element class.
-     * @param t  Type (vector or tensor).
+     * @brief Constructor for FEVectorContravariant and FEVectorPiola.
+     * @param fe Base finite element class (must be scalar).
+     * @param t  Type (must be FEVectorContravariant or FEVectorPiola).
      */
     FESystem(std::shared_ptr<FiniteElement<dim> > fe, FEType t);
     
     /**
-     * @brief Constructor. FESystem with @p n components created from a scalar FE.
-     * @param fe Base finite element class.
+     * @brief Constructor for FEVector, FETensor and FEMixedSystem.
+     * If @p t == FEVector then @p n must be the space dimension into which
+     * the reference cell will be mapped and that @p fe is scalar.
+     * If @p t == FETensor then @p n must be square of the space dimension into which
+     * the reference cell will be mapped and that @p fe is scalar.
+     * If @p t == FEMixedSystem, then @p n is the number of components.
+     * @param fe Base finite element class (must be scalar if @p t is FEVector or FETensor).
+     * @param t  Type of FESystem (must be either FEVector, FETensor or FEMixedSystem).
      * @param n  Multiplicity (number of components).
      */
-    FESystem(const std::shared_ptr<FiniteElement<dim> > &fe, unsigned int n);
+    FESystem(const std::shared_ptr<FiniteElement<dim> > &fe, FEType t, unsigned int n);
     
     /**
      * @brief Constructor. FESystem for mixed elements.
@@ -125,6 +131,9 @@ public:
     
     std::vector<unsigned int> get_vector_components() const
     { return vector_components_; }
+    
+    std::vector<unsigned int> get_tensor_components() const
+    { return tensor_components_; }
 
     UpdateFlags update_each(UpdateFlags flags) override;
     
@@ -144,6 +153,7 @@ private:
   
   std::vector<unsigned int> scalar_components_;
   std::vector<unsigned int> vector_components_;
+  std::vector<unsigned int> tensor_components_;
   
 };
 

--- a/src/fem/fe_values.cc
+++ b/src/fem/fe_values.cc
@@ -88,26 +88,31 @@ void FEValuesBase<dim,spacedim>::ViewsCache::initialize(FEValuesBase<dim,spacedi
 {
   scalars.clear();
   vectors.clear();
+  tensors.clear();
   switch (fv.get_fe()->type_) {
     case FEType::FEScalar:
       scalars.push_back(FEValuesViews::Scalar<dim,spacedim>(fv, 0));
       break;
+    case FEType::FEVector:
     case FEType::FEVectorContravariant:
     case FEType::FEVectorPiola:
       vectors.push_back(FEValuesViews::Vector<dim,spacedim>(fv, 0));
       break;
     case FEType::FETensor:
-      OLD_ASSERT(false, "Not Implemented.");
+      tensors.push_back(FEValuesViews::Tensor<dim,spacedim>(fv, 0));
       break;
     case FEType::FEMixedSystem:
       FESystem<dim> *fe = dynamic_cast<FESystem<dim>*>(fv.get_fe());
       OLD_ASSERT(fe != nullptr, "Mixed system must be represented by FESystem.");
       std::vector<unsigned int> sc = fe->get_scalar_components();
       std::vector<unsigned int> vc = fe->get_vector_components();
+      std::vector<unsigned int> tc = fe->get_tensor_components();
       for (auto si : sc)
         scalars.push_back(FEValuesViews::Scalar<dim,spacedim>(fv,si));
       for (auto vi : vc)
         vectors.push_back(FEValuesViews::Vector<dim,spacedim>(fv,vi));
+      for (auto ti : tc)
+        tensors.push_back(FEValuesViews::Tensor<dim,spacedim>(fv,ti));
       break;
   }
 }
@@ -136,6 +141,13 @@ void FEValuesBase<dim,spacedim>::allocate(Mapping<dim,spacedim> & _mapping,
         FiniteElement<dim> & _fe,
         UpdateFlags _flags)
 {
+    // For FEVector and FETensor check number of components.
+    // This cannot be done in FiniteElement since it does not know spacedim.
+    if (_fe.type_ == FEVector)
+        ASSERT_DBG(_fe.n_components() == spacedim).error("FEVector must have spacedim components.");
+    else if (_fe.type_ == FETensor)
+        ASSERT_DBG(_fe.n_components() == spacedim*spacedim).error("FETensor must have spacedim*spacedim components.");
+    
     mapping = &_mapping;
     quadrature = &_quadrature;
     fe = &_fe;
@@ -144,6 +156,7 @@ void FEValuesBase<dim,spacedim>::allocate(Mapping<dim,spacedim> & _mapping,
         case FEScalar:
             n_components_ = 1;
             break;
+        case FEVector:
         case FEVectorContravariant:
         case FEVectorPiola:
             n_components_ = spacedim;
@@ -269,6 +282,37 @@ void FEValuesBase<dim,spacedim>::fill_scalar_data(const FEInternalData &fe_data)
 
 
 template<unsigned int dim, unsigned int spacedim>
+void FEValuesBase<dim,spacedim>::fill_vec_data(const FEInternalData &fe_data)
+{
+    ASSERT_DBG(fe->type_ == FEVector);
+    
+    // shape values
+    if (data.update_flags & update_values)
+    {
+        for (unsigned int i = 0; i < fe_data.n_points; i++)
+            for (unsigned int j = 0; j < fe_data.n_dofs; j++)
+            {
+                arma::vec fv_vec = fe_data.ref_shape_values[i][j];
+                for (unsigned int c=0; c<spacedim; c++)
+                    data.shape_values[i][j*spacedim+c] = fv_vec[c];
+            }
+    }
+
+    // shape gradients
+    if (data.update_flags & update_gradients)
+    {
+        for (unsigned int i = 0; i < fe_data.n_points; i++)
+            for (unsigned int j = 0; j < fe_data.n_dofs; j++)
+            {
+                arma::mat grads = trans(data.inverse_jacobians[i]) * fe_data.ref_shape_grads[i][j];
+                for (unsigned int c=0; c<spacedim; c++)
+                    data.shape_gradients[i][j*spacedim+c] = grads.col(c);
+            }
+    }
+}
+
+
+template<unsigned int dim, unsigned int spacedim>
 void FEValuesBase<dim,spacedim>::fill_vec_contravariant_data(const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe->type_ == FEVectorContravariant);
@@ -327,6 +371,37 @@ void FEValuesBase<dim,spacedim>::fill_vec_piola_data(const FEInternalData &fe_da
                 for (unsigned int c=0; c<spacedim; c++)
                     data.shape_gradients[i][j*spacedim+c] = grads.col(c);
             }   
+    }
+}
+
+
+template<unsigned int dim, unsigned int spacedim>
+void FEValuesBase<dim,spacedim>::fill_tensor_data(const FEInternalData &fe_data)
+{
+    ASSERT_DBG(fe->type_ == FETensor);
+    
+    // shape values
+    if (data.update_flags & update_values)
+    {
+        for (unsigned int i = 0; i < fe_data.n_points; i++)
+            for (unsigned int j = 0; j < fe_data.n_dofs; j++)
+            {
+                arma::vec fv_vec = fe_data.ref_shape_values[i][j];
+                for (unsigned int c=0; c<spacedim*spacedim; c++)
+                    data.shape_values[i][j*spacedim*spacedim+c] = fv_vec[c];
+            }
+    }
+
+    // shape gradients
+    if (data.update_flags & update_gradients)
+    {
+        for (unsigned int i = 0; i < fe_data.n_points; i++)
+            for (unsigned int j = 0; j < fe_data.n_dofs; j++)
+            {
+                arma::mat grads = trans(data.inverse_jacobians[i]) * fe_data.ref_shape_grads[i][j];
+                for (unsigned int c=0; c<spacedim*spacedim; c++)
+                    data.shape_gradients[i][j*spacedim*spacedim+c] = grads.col(c);
+            }
     }
 }
 
@@ -396,11 +471,17 @@ void FEValuesBase<dim,spacedim>::fill_data(const FEInternalData &fe_data)
         case FEScalar:
             fill_scalar_data(fe_data);
             break;
+        case FEVector:
+            fill_vec_data(fe_data);
+            break;
         case FEVectorContravariant:
             fill_vec_contravariant_data(fe_data);
             break;
         case FEVectorPiola:
             fill_vec_piola_data(fe_data);
+            break;
+        case FETensor:
+            fill_tensor_data(fe_data);
             break;
         case FEMixedSystem:
             fill_system_data(fe_data);

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -229,6 +229,7 @@ private:
   struct ViewsCache {
     vector<FEValuesViews::Scalar<dim,spacedim> > scalars;
     vector<FEValuesViews::Vector<dim,spacedim> > vectors;
+    vector<FEValuesViews::Tensor<dim,spacedim> > tensors;
     
     void initialize(FEValuesBase &fv);
   };
@@ -389,6 +390,16 @@ public:
       ASSERT_LT_DBG(i, views_cache_.vectors.size());
       return views_cache_.vectors[i];
     }
+    
+    /**
+     * @brief Accessor to tensor values of multicomponent FE.
+     * @param i Index of first tensor component.
+     */
+    const FEValuesViews::Tensor<dim,spacedim> &tensor_view(unsigned int i) const
+    {
+      ASSERT_LT_DBG(i, views_cache_.tensors.size());
+      return views_cache_.tensors[i];
+    }
 
     /**
      * @brief Returns the number of quadrature points.
@@ -448,10 +459,16 @@ protected:
     void fill_scalar_data(const FEInternalData &fe_data);
     
     /// Compute shape functions and gradients on the actual cell for vectorial FE.
+    void fill_vec_data(const FEInternalData &fe_data);
+    
+    /// Compute shape functions and gradients on the actual cell for vectorial FE.
     void fill_vec_contravariant_data(const FEInternalData &fe_data);
     
     /// Compute shape functions and gradients on the actual cell for Raviart-Thomas FE.
     void fill_vec_piola_data(const FEInternalData &fe_data);
+    
+    /// Compute shape functions and gradients on the actual cell for tensorial FE.
+    void fill_tensor_data(const FEInternalData &fe_data);
     
     /// Compute shape functions and gradients on the actual cell for mixed system of FE.
     void fill_system_data(const FEInternalData &fe_data);

--- a/src/fem/fe_values_views.cc
+++ b/src/fem/fe_values_views.cc
@@ -92,6 +92,50 @@ double FEValuesViews::Vector<dim,spacedim>::divergence(unsigned int function_no,
 template<unsigned int dim, unsigned int spacedim>
 FEValuesBase<dim,spacedim> &FEValuesViews::Vector<dim,spacedim>::base() const
 { return fe_values_; }
+
+
+
+template<unsigned int dim, unsigned int spacedim>
+arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<dim,spacedim>::value(unsigned int function_no, unsigned int point_no) const
+{
+  ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
+  ASSERT_LT_DBG( point_no, fe_values_.n_points() );
+  arma::mat::fixed<spacedim,spacedim> v;
+  for (unsigned int c=0; c<spacedim*spacedim; ++c)
+    v(c/spacedim,c%spacedim) = fe_values_.shape_value_component(function_no, point_no, first_tensor_component_+c);
+  return v;
+}
+
+template<unsigned int dim, unsigned int spacedim>
+arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<dim,spacedim>::derivative(
+    unsigned int variable_no,
+    unsigned int function_no, 
+    unsigned int point_no) const
+{
+  ASSERT_LT_DBG( variable_no, spacedim );
+  ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
+  ASSERT_LT_DBG( point_no, fe_values_.n_points() );
+  arma::mat::fixed<spacedim,spacedim> g;
+  for (unsigned int c=0; c<spacedim*spacedim; ++c)
+    g(c/spacedim,c%spacedim) = fe_values_.shape_grad_component(function_no, point_no, first_tensor_component_+c)[first_tensor_component_+variable_no];
+  return g;
+}
+
+template<unsigned int dim, unsigned int spacedim>
+arma::vec::fixed<spacedim> FEValuesViews::Tensor<dim,spacedim>::divergence(unsigned int function_no, unsigned int point_no) const
+{
+  ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
+  ASSERT_LT_DBG( point_no, fe_values_.n_points() );
+  arma::vec::fixed<spacedim> div;
+  div.zeros();
+  for (unsigned int c=0; c<spacedim*spacedim; ++c)
+    div(c%spacedim) += fe_values_.shape_grad_component(function_no, point_no, first_tensor_component_+c)[first_tensor_component_+c/spacedim];
+  return div;
+}
+
+template<unsigned int dim, unsigned int spacedim>
+FEValuesBase<dim,spacedim> &FEValuesViews::Tensor<dim,spacedim>::base() const
+{ return fe_values_; }
   
 
 
@@ -104,5 +148,9 @@ template class FEValuesViews::Scalar<3,3>;
 template class FEValuesViews::Vector<1,3>;
 template class FEValuesViews::Vector<2,3>;
 template class FEValuesViews::Vector<3,3>;
+
+template class FEValuesViews::Tensor<1,3>;
+template class FEValuesViews::Tensor<2,3>;
+template class FEValuesViews::Tensor<3,3>;
 
 

--- a/src/fem/fe_values_views.hh
+++ b/src/fem/fe_values_views.hh
@@ -123,7 +123,56 @@ namespace FEValuesViews {
   
   
   template<unsigned int dim, unsigned int spacedim>
-  class Tensor {};
+  class Tensor {
+      
+  public:
+    
+    Tensor(FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+      : fe_values_(fe_values),
+        first_tensor_component_(component)
+    {};
+    
+    /**
+     * @brief Return value of tensor-valued shape function.
+     * @param function_no Index of shape function within the FE.
+     * @param point_no    Index of quadrature point.
+     */
+    arma::mat::fixed<spacedim,spacedim> value(unsigned int function_no, unsigned int point_no) const;
+    
+    /**
+     * @brief Return partial derivative of tensor-valued shape function.
+     * @param variable_no Index of spacial variable w.r. to which we differentiate.
+     * @param function_no Index of shape function within the FE.
+     * @param point_no    Index of quadrature point.
+     */
+    arma::mat::fixed<spacedim,spacedim> derivative(
+        unsigned int variable_no,
+        unsigned int function_no,
+        unsigned int point_no) const;
+    
+    /**
+     * @brief Return divergence of tensor-valued shape function.
+     * 
+     * The result is a vector whose components are divergences of tensor columns, i.e.
+     * (div T)_i = dT_ji / dx_j.
+     * 
+     * @param function_no Index of shape function within the FE.
+     * @param point_no    Index of quadrature point.
+     */
+    arma::vec::fixed<spacedim> divergence(unsigned int function_no, unsigned int point_no) const;
+    
+    /// Returns the FEValuesBase class.
+    FEValuesBase<dim,spacedim> &base() const;
+    
+  private:
+    
+    /// Base FEValues class for access to the FE.
+    FEValuesBase<dim,spacedim> &fe_values_;
+    
+    /// Index of the first component of the vector.
+    unsigned int first_tensor_component_;
+    
+  };
 
 };
 

--- a/src/fem/finite_element.cc
+++ b/src/fem/finite_element.cc
@@ -149,6 +149,8 @@ UpdateFlags FiniteElement<dim>::update_each(UpdateFlags flags)
     switch (type_)
     {
         case FEScalar:   
+        case FEVector:
+        case FETensor:
             if (flags & update_gradients)
                 f |= update_inverse_jacobians;
             break;

--- a/src/fem/finite_element.hh
+++ b/src/fem/finite_element.hh
@@ -185,8 +185,8 @@ protected:
  * 
  *     TYPE              OBJECT  EXPRESSION
  * -----------------------------------------------------------
- * FEScalar              value   ref_value
- *                       grad    J^{-T} * ref_grad
+ * FEScalar, FEVector,   value   ref_value
+ * FETensor              grad    J^{-T} * ref_grad
  * -----------------------------------------------------------
  * FEVectorContravariant value   J * ref_value
  *                       grad    J^{-T} * ref_grad * J^T
@@ -194,20 +194,20 @@ protected:
  * FEVectorPiola         value   J * ref_value / |J|
  *                       grad    J^{-T} * ref_grad * J^T / |J|
  * -----------------------------------------------------------
- * FETensor              value   not implemented
- *                       grad    not implemented
- * -----------------------------------------------------------
  * FEMixedSystem         value   depends on sub-elements
  *                       grad    depends on sub-elements
+ * 
+ * The transformation itself is done in FEValuesBase::fill_..._data() methods.
  * 
  * Note that we use columnwise gradients, i.e. gradient of each component is a column vector.
  */
 enum FEType {
   FEScalar = 0,
-  FEVectorContravariant = 1,
-  FEVectorPiola = 2,
-  FETensor = 3,
-  FEMixedSystem = 4
+  FEVector = 1,
+  FEVectorContravariant = 2,
+  FEVectorPiola = 3,
+  FETensor = 4,
+  FEMixedSystem = 5
 };
 
 


### PR DESCRIPTION
These two finite element types serve for tensor/vector-valued elements that are mapped from reference cell to cell in space dimension just by change of coordinates.