### PR TITLE
Js use armor

### DIFF
--- a/src/quadrature/qmidpoint.hh
+++ b/src/quadrature/qmidpoint.hh
@@ -35,7 +35,7 @@ public:
         this->weights.resize(n_quadrature_points,qweight);
         this->quadrature_points.resize(n_quadrature_points);
         for(unsigned int q=0; q < n_quadrature_points; q++)
-            this->quadrature_points[q] = arma::vec({0.5*qweight + q*qweight});
+            this->set_point(q, arma::vec({0.5*qweight + q*qweight}));
     }
 };
 

--- a/src/quadrature/quadrature.hh
+++ b/src/quadrature/quadrature.hh
@@ -22,7 +22,10 @@
 #include <armadillo>
 #include <vector>
 
+#include "system/armor.hh"
 #include "mesh/ref_element.hh"
+
+
 
 /**
  * @brief Base class for quadrature rules on simplices in arbitrary dimensions.
@@ -74,10 +77,10 @@ public:
     const unsigned int size() const;
 
     /// Returns the <tt>i</tt>th quadrature point.
-    const arma::vec::fixed<dim> & point(const unsigned int i) const;
+    arma::vec::fixed<dim> point(const unsigned int i) const;
 
     /// Return a reference to the whole array of quadrature points.
-    const std::vector<arma::vec::fixed<dim> > & get_points() const;
+    const Armor::array & get_points() const;
 
     /**
      * @brief Sets individual quadrature point coordinates.
@@ -101,7 +104,7 @@ protected:
      *
      * To be filled by the constructors of the derived classes.
      */
-    std::vector<arma::vec::fixed<dim> > quadrature_points;
+    Armor::array quadrature_points;
 
     /**
      * @brief List of weights to the quadrature points.
@@ -116,9 +119,9 @@ protected:
 
 template<unsigned int dim>
 Quadrature<dim>::Quadrature(const unsigned int n_q)
-{
-    resize(n_q);
-}
+: quadrature_points(n_q, dim),
+  weights(n_q, 0)
+{}
 
 template<unsigned int dim>
 Quadrature<dim>::Quadrature(const Quadrature<dim> &q) :
@@ -129,9 +132,7 @@ Quadrature<dim>::Quadrature(const Quadrature<dim> &q) :
 template<unsigned int dim>
 void Quadrature<dim>::resize(const unsigned int n_q)
 {
-    arma::vec::fixed<dim> v;
-    v.fill(0);
-    quadrature_points.resize(n_q, v);
+    quadrature_points.resize(n_q);
     weights.resize(n_q, 0);
 }
 
@@ -141,20 +142,20 @@ inline const unsigned int Quadrature<dim>::size() const {
 }
 
 template<unsigned int dim>
-inline const arma::vec::fixed<dim> & Quadrature<dim>::point(
+inline arma::vec::fixed<dim> Quadrature<dim>::point(
         const unsigned int i) const {
-    return quadrature_points[i];
+    return quadrature_points.get<dim>(i).arma();
 }
 
 template<unsigned int dim>
-inline const std::vector<arma::vec::fixed<dim> > & Quadrature<dim>::get_points() const {
+inline const Armor::array & Quadrature<dim>::get_points() const {
     return quadrature_points;
 }
 
 template<unsigned int dim>
 inline void Quadrature<dim>::set_point(const unsigned int i, const arma::vec::fixed<dim> &p)
 {
-    quadrature_points[i] = p;
+    quadrature_points.get<dim>(i) = p;
 }
 
 template<unsigned int dim>
@@ -179,6 +180,7 @@ Quadrature<dim>::~Quadrature()
 
 template<unsigned int dim> inline
 Quadrature<dim>::Quadrature(const Quadrature<dim-1> &subq, unsigned int sid, unsigned int pid)
+: quadrature_points(subq.size(), dim)
 {
     // Below we permute point coordinates according to permutation
     // of nodes on side. We just check that these numbers equal.
@@ -233,7 +235,7 @@ Quadrature<dim>::Quadrature(const Quadrature<dim-1> &subq, unsigned int sid, uns
         el_bar_coords = RefElement<dim>::template interpolate<dim-1>(pp,sid);
         
         //get local coordinates and set
-        quadrature_points[k] = RefElement<dim>::bary_to_local(el_bar_coords);
+        quadrature_points.get<dim>(k) = RefElement<dim>::bary_to_local(el_bar_coords);
         weights[k] = subq.weight(k);
     }
 }
@@ -241,9 +243,9 @@ Quadrature<dim>::Quadrature(const Quadrature<dim-1> &subq, unsigned int sid, uns
 // Specialized subquadrature consructor for dim=1.
 template<> inline
 Quadrature<1>::Quadrature(const Quadrature<0> &subq, unsigned int sid, unsigned int pid)
+: quadrature_points(1, 1)
 {
-    arma::vec::fixed<1> p({(double)sid});
-    quadrature_points.push_back(p);
+    quadrature_points.get<1>(0) = { (double)sid };
     weights.push_back(1);
 }
 

--- a/src/quadrature/quadrature_lib.cc
+++ b/src/quadrature/quadrature_lib.cc
@@ -65,12 +65,11 @@ QGauss<dim>::QGauss(const unsigned int order)
     static const double unit_cell_volume[] = { 1, 1, 0.5, 1./6 };
     const pQUAD *q;
     unsigned int nquads;
-    vec::fixed<dim> p;
 
     switch (dim)
     {
     case 0:
-        this->quadrature_points.push_back(p);
+        this->quadrature_points.push_back({});
         this->weights.push_back(1);
         return;
     case 1:
@@ -89,10 +88,11 @@ QGauss<dim>::QGauss(const unsigned int order)
 
     OLD_ASSERT(order < nquads, "Quadrature of given order is not implemented.");
 
+    vector<double> p(dim, 0);
     for (int i=0; i<q[order]->npoints; i++)
     {
         for (unsigned int j=0; j<dim; j++)
-            p(j) = q[order]->points[i*(dim+1)+j];
+            p[j] = q[order]->points[i*(dim+1)+j];
 
         this->quadrature_points.push_back(p);
         // The weights must be adjusted according to the volume of the unit cell:

--- a/src/system/armor.hh
+++ b/src/system/armor.hh
@@ -1,3 +1,6 @@
+#ifndef ARMOR_HH
+#define ARMOR_HH
+
 //#define ARMA_DONT_USE_WRAPPER
 //#define ARMA_NO_DEBUG
 #include <armadillo>
@@ -9,45 +12,24 @@ template <class Type, uint nRows, uint nCols>
 class Mat
 {
 private:
-    std::array<std::array<Type, nRows>, nCols> data;
+    Type * const data;
     typedef typename arma::Mat<Type>::template fixed<nRows,nCols> ArmaType;
 public:
-    Mat() {
+    Mat(Type * const mem)
+    : data(mem)
+    {}
+    inline Mat(const Armor::Mat<Type, nRows, nCols> & other) 
+    : data(other.data)
+    {
         for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = 0;
-        }
-    }
-    Mat(std::initializer_list<std::initializer_list<Type>> list) {
-        const auto * listIt = list.begin();
-        const Type * it;
-        for (uint i = 0; i < nRows; ++i) {
-            it = (listIt + i)->begin();
-            for (uint j = 0; j < nCols; ++j) {
-                data[j][i] = *(it + j);
-            }
-        }
-    }
-    Mat(std::initializer_list<Type> list) {
-        const Type * it = list.begin();
-        for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = *(it + i);
-        }
-    }
-    inline Mat(const Armor::Mat<Type, nRows, nCols> & other) {
-        for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = other[i];
-        }
-    }
-    inline Mat(const ArmaType & other) {
-        for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = other[i];
+            data[i] = other[i];
         }
     }
     inline const Type * begin() const {
-        return data.data()->data();
+        return data;
     }
     inline Type * begin() {
-        return data.data()->data();
+        return data;
     }
     inline const Type * end() const {
         return begin() + nCols * nRows;
@@ -62,29 +44,29 @@ public:
         return begin();
     }
     inline const Type & operator[](uint index) const {
-        return data[0][index];
+        return data[index];
     }
     inline Type & operator[](uint index) {
-        return data[0][index];
+        return data[index];
     }
     inline const Type & operator()(uint row, uint col) const {
-        return data[col][row];
+        return data[row*nCols+col];
     }
     inline Type & operator()(uint row, uint col) {
-        return data[col][row];
+        return data[row*nCols+col];
     }
     inline ArmaType arma() const {
         return ArmaType(begin());
     }
     inline const Mat<Type, nRows, nCols> & operator=(const Mat<Type, nRows, nCols> & other) {
         for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = other[i];
+            data[i] = other[i];
         }
         return *this;
     }
     inline const Mat<Type, nRows, nCols> & operator=(const ArmaType & other) {        
         for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = other[i];
+            data[i] = other[i];
         }
         return *this;
     }
@@ -94,7 +76,7 @@ public:
         for (uint i = 0; i < nRows; ++i) {
             it = (listIt + i)->begin();
             for (uint j = 0; j < nCols; ++j) {
-                data[j][i] = *(it + j);
+                data[i*nCols+j] = *(it + j);
             }
         }
         return *this;
@@ -102,7 +84,7 @@ public:
     inline const Mat<Type, nRows, nCols> & operator=(std::initializer_list<Type> list) {
         const Type * it = list.begin();
         for (uint i = 0; i < nRows * nCols; ++i) {
-            data[0][i] = *(it + i);
+            data[i] = *(it + i);
         }
         return *this;
     }
@@ -172,3 +154,5 @@ template <uint N, uint M>
 using mat = Mat<double, N, M>;
 
 }
+
+#endif

--- a/src/system/armor.hh
+++ b/src/system/armor.hh
@@ -115,8 +115,8 @@ public:
 
 
 /**
- * Array of Armor::Mat with given shape. Provides contiguous storage for the data and read access to the array elements.
- * The shape of the matrices is specified at initialization, so the class Array is independent of additional template parameters.
+ * Array of Armor::Mat with given shape. Provides contiguous storage for the data and access to the array elements.
+ * The shape of the matrices is specified at run time, so the class Array is independent of additional template parameters.
  * However, to access the array elements, one must use the templated method get().
  */
 template<class Type>


### PR DESCRIPTION
- Proposal of Armor::Array class providing a vector (array) of matrices without having the matrix size as template parameter.
- Application in Quadrature point coordinates. The aim is to make the class Quadrature non-templated.

Related to #1136.