### PR TITLE
Js fe values without dim

### DIFF
--- a/src/fem/element_values.cc
+++ b/src/fem/element_values.cc
@@ -62,11 +62,11 @@ ElementData<spacedim>::ElementData(unsigned int size,
 template<unsigned int spacedim>
 void ElementData<spacedim>::print()
 {
-    if (cell.is_valid() || side.is_valid())
+    if (cell.is_valid() || side.valid())
     {
         if (cell.is_valid())
             printf("cell %d dim %d ", cell.elm_idx(), cell.dim());
-        else if (side.is_valid())
+        else if (side.valid())
             printf("cell %d dim %d side %d ", side.elem_idx(), side.dim(), side.side_idx());
         
         printf(" det[");
@@ -214,7 +214,7 @@ ElementValues<spacedim>::~ElementValues()
 
 
 template<unsigned int spacedim>
-void ElementValues<spacedim>::reinit(const DHCellAccessor & cell)
+void ElementValues<spacedim>::reinit(const ElementAccessor<spacedim> & cell)
 {
 	OLD_ASSERT_EQUAL( dim_, cell.dim() );
     data.cell = cell;
@@ -239,7 +239,7 @@ void ElementValues<spacedim>::reinit(const DHCellAccessor & cell)
 
 
 template<unsigned int spacedim>
-void ElementValues<spacedim>::reinit(const DHCellSide & cell_side)
+void ElementValues<spacedim>::reinit(const Side & cell_side)
 {
     ASSERT_EQ_DBG( dim_, cell_side.dim() );
     data.side = cell_side;
@@ -280,7 +280,7 @@ void ElementValues<spacedim>::fill_data()
         (data.update_flags & update_quadrature_points))
     {
         if (cell().is_valid())
-            coords = MappingP1<dim,spacedim>::element_map(cell().elm());
+            coords = MappingP1<dim,spacedim>::element_map(cell());
         else
             coords = MappingP1<dim,spacedim>::element_map(side().element());
     }
@@ -382,7 +382,7 @@ void ElementValues<spacedim>::fill_side_data()
             // calculation of side Jacobian
             for (unsigned int n=0; n<dim; n++)
                 for (unsigned int c=0; c<spacedim; c++)
-                    side_coords(c,n) = (*data.side.side().node(n))[c];
+                    side_coords(c,n) = (*data.side.node(n))[c];
             side_jac = MappingP1<MatrixSizes<dim>::dim_minus_one,spacedim>::jacobian(side_coords);
 
             // calculation of JxW

--- a/src/fem/element_values.hh
+++ b/src/fem/element_values.hh
@@ -112,10 +112,10 @@ public:
     UpdateFlags update_flags;
 
     /// Iterator to last updated cell.
-    DHCellAccessor cell;
+    ElementAccessor<spacedim> cell;
 
     /// Iterator to last updated cell side.
-    DHCellSide side;
+    Side side;
 
 };
 
@@ -155,14 +155,14 @@ public:
      *
      * @param cell The actual cell.
      */
-    void reinit(const DHCellAccessor &cell);
+    void reinit(const ElementAccessor<spacedim> &cell);
 
     /**
 	 * @brief Update side-dependent data (Jacobians etc.)
 	 *
 	 * @param cell_side The actual cell and side.
 	 */
-    void reinit(const DHCellSide &cell_side);
+    void reinit(const Side &cell_side);
     
     /**
      * @brief Determine quantities to be recomputed on each cell.
@@ -257,11 +257,11 @@ public:
     { return n_points_; }
     
     /// Return cell at which the values were reinited.
-    const DHCellAccessor &cell() const
+    const ElementAccessor<spacedim> &cell() const
     { return data.cell; }
 
     /// Return cell side where the values were reinited.
-    const DHCellSide &side() const
+    const Side &side() const
     { return data.side; }
 
 

--- a/src/fem/fe_system.hh
+++ b/src/fem/fe_system.hh
@@ -144,7 +144,7 @@ public:
     virtual std::vector< arma::vec::fixed<dim+1> > dof_points() const;
 
 
-    const std::vector<std::shared_ptr<FiniteElement<dim> > > &fe()
+    const std::vector<std::shared_ptr<FiniteElement<dim> > > &fe() const
     { return fe_; }
     
     /// Return dof indices belonging to given sub-FE.

--- a/src/fem/fe_values.cc
+++ b/src/fem/fe_values.cc
@@ -36,8 +36,8 @@ using namespace std;
 
 
 
-template<unsigned int dim,unsigned int spacedim>
-FEValuesBase<dim,spacedim>::FEInternalData::FEInternalData(unsigned int np, unsigned int nd)
+template<unsigned int spacedim>
+FEValuesBase<spacedim>::FEInternalData::FEInternalData(unsigned int np, unsigned int nd)
     : n_points(np),
       n_dofs(nd)
 {
@@ -46,8 +46,8 @@ FEValuesBase<dim,spacedim>::FEInternalData::FEInternalData(unsigned int np, unsi
 }
 
 
-template<unsigned int dim,unsigned int spacedim>
-FEValuesBase<dim,spacedim>::FEInternalData::FEInternalData(const FEInternalData &fe_system_data,
+template<unsigned int spacedim>
+FEValuesBase<spacedim>::FEInternalData::FEInternalData(const FEInternalData &fe_system_data,
                                const std::vector<unsigned int> &dof_indices,
                                unsigned int first_component_idx,
                                unsigned int ncomps)
@@ -63,23 +63,24 @@ FEValuesBase<dim,spacedim>::FEInternalData::FEInternalData(const FEInternalData 
 
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::ViewsCache::initialize(const FEValuesBase<dim,spacedim> &fv, const FiniteElement<dim> &fe)
+template<unsigned int spacedim>
+template<unsigned int dim>
+void FEValuesBase<spacedim>::ViewsCache::initialize(const FEValuesBase<spacedim> &fv, const FiniteElement<dim> &fe)
 {
   scalars.clear();
   vectors.clear();
   tensors.clear();
   switch (fe.type_) {
     case FEType::FEScalar:
-      scalars.push_back(FEValuesViews::Scalar<dim,spacedim>(fv, 0));
+      scalars.push_back(FEValuesViews::Scalar<spacedim>(fv, 0));
       break;
     case FEType::FEVector:
     case FEType::FEVectorContravariant:
     case FEType::FEVectorPiola:
-      vectors.push_back(FEValuesViews::Vector<dim,spacedim>(fv, 0));
+      vectors.push_back(FEValuesViews::Vector<spacedim>(fv, 0));
       break;
     case FEType::FETensor:
-      tensors.push_back(FEValuesViews::Tensor<dim,spacedim>(fv, 0));
+      tensors.push_back(FEValuesViews::Tensor<spacedim>(fv, 0));
       break;
     case FEType::FEMixedSystem:
       const FESystem<dim> *fe_sys = dynamic_cast<const FESystem<dim>*>(&fe);
@@ -94,15 +95,15 @@ void FEValuesBase<dim,spacedim>::ViewsCache::initialize(const FEValuesBase<dim,s
           switch (fe->type_)
           {
           case FEType::FEScalar:
-              scalars.push_back(FEValuesViews::Scalar<dim,spacedim>(fv,comp_offset));
+              scalars.push_back(FEValuesViews::Scalar<spacedim>(fv,comp_offset));
               break;
           case FEType::FEVector:
           case FEType::FEVectorContravariant:
           case FEType::FEVectorPiola:
-              vectors.push_back(FEValuesViews::Vector<dim,spacedim>(fv,comp_offset));
+              vectors.push_back(FEValuesViews::Vector<spacedim>(fv,comp_offset));
               break;
           case FEType::FETensor:
-              tensors.push_back(FEValuesViews::Tensor<dim,spacedim>(fv,comp_offset));
+              tensors.push_back(FEValuesViews::Tensor<spacedim>(fv,comp_offset));
               break;
           default:
               ASSERT_DBG(false).error("Not implemented.");
@@ -117,23 +118,24 @@ void FEValuesBase<dim,spacedim>::ViewsCache::initialize(const FEValuesBase<dim,s
 
 
 
-template<unsigned int dim,unsigned int spacedim>
-FEValuesBase<dim,spacedim>::FEValuesBase()
+template<unsigned int spacedim>
+FEValuesBase<spacedim>::FEValuesBase()
 : n_points_(0), n_dofs_(0), elm_values(nullptr)
 {
 }
 
 
 
-template<unsigned int dim,unsigned int spacedim>
-FEValuesBase<dim,spacedim>::~FEValuesBase() {
+template<unsigned int spacedim>
+FEValuesBase<spacedim>::~FEValuesBase() {
     if (elm_values != nullptr) delete elm_values;
 }
 
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::allocate(
+template<unsigned int spacedim>
+template<unsigned int dim>
+void FEValuesBase<spacedim>::allocate(
         unsigned int n_points,
         FiniteElement<dim> & _fe,
         UpdateFlags _flags)
@@ -175,8 +177,9 @@ void FEValuesBase<dim,spacedim>::allocate(
 
 
 
-template<unsigned int dim, unsigned int spacedim>
-typename FEValuesBase<dim,spacedim>::FEInternalData *FEValuesBase<dim,spacedim>::init_fe_data(const FiniteElement<dim> &fe, const Quadrature &q)
+template<unsigned int spacedim>
+template<unsigned int dim>
+typename FEValuesBase<spacedim>::FEInternalData *FEValuesBase<spacedim>::init_fe_data(const FiniteElement<dim> &fe, const Quadrature &q)
 {
     ASSERT_DBG( q.dim() == dim );
     FEInternalData *data = new FEInternalData(q.size(), n_dofs_);
@@ -210,8 +213,8 @@ typename FEValuesBase<dim,spacedim>::FEInternalData *FEValuesBase<dim,spacedim>:
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-double FEValuesBase<dim,spacedim>::shape_value(const unsigned int function_no, const unsigned int point_no)
+template<unsigned int spacedim>
+double FEValuesBase<spacedim>::shape_value(const unsigned int function_no, const unsigned int point_no)
 {
   ASSERT_LT_DBG(function_no, n_dofs_);
   ASSERT_LT_DBG(point_no, n_points_);
@@ -219,8 +222,8 @@ double FEValuesBase<dim,spacedim>::shape_value(const unsigned int function_no, c
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-arma::vec::fixed<spacedim> FEValuesBase<dim,spacedim>::shape_grad(const unsigned int function_no, const unsigned int point_no)
+template<unsigned int spacedim>
+arma::vec::fixed<spacedim> FEValuesBase<spacedim>::shape_grad(const unsigned int function_no, const unsigned int point_no)
 {
   ASSERT_LT_DBG(function_no, n_dofs_);
   ASSERT_LT_DBG(point_no, n_points_);
@@ -228,8 +231,8 @@ arma::vec::fixed<spacedim> FEValuesBase<dim,spacedim>::shape_grad(const unsigned
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-double FEValuesBase<dim,spacedim>::shape_value_component(const unsigned int function_no, 
+template<unsigned int spacedim>
+double FEValuesBase<spacedim>::shape_value_component(const unsigned int function_no, 
                                     const unsigned int point_no, 
                                     const unsigned int comp) const
 {
@@ -240,8 +243,8 @@ double FEValuesBase<dim,spacedim>::shape_value_component(const unsigned int func
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-arma::vec::fixed<spacedim> FEValuesBase<dim,spacedim>::shape_grad_component(const unsigned int function_no,
+template<unsigned int spacedim>
+arma::vec::fixed<spacedim> FEValuesBase<spacedim>::shape_grad_component(const unsigned int function_no,
                                                         const unsigned int point_no,
                                                         const unsigned int comp) const
 {
@@ -252,8 +255,8 @@ arma::vec::fixed<spacedim> FEValuesBase<dim,spacedim>::shape_grad_component(cons
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_scalar_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_scalar_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe_type_ == FEScalar);
     
@@ -271,9 +274,9 @@ void FEValuesBase<dim,spacedim>::fill_scalar_data(const ElementValues<spacedim> 
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_vec_data(const ElementValues<spacedim> &elm_values,
-                                               const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_vec_data(const ElementValues<spacedim> &elm_values,
+                                           const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe_type_ == FEVector);
     
@@ -303,9 +306,9 @@ void FEValuesBase<dim,spacedim>::fill_vec_data(const ElementValues<spacedim> &el
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_vec_contravariant_data(const ElementValues<spacedim> &elm_values,
-                                                             const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_vec_contravariant_data(const ElementValues<spacedim> &elm_values,
+                                                         const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe_type_ == FEVectorContravariant);
     
@@ -335,9 +338,9 @@ void FEValuesBase<dim,spacedim>::fill_vec_contravariant_data(const ElementValues
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_vec_piola_data(const ElementValues<spacedim> &elm_values,
-                                                     const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_vec_piola_data(const ElementValues<spacedim> &elm_values,
+                                                 const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe_type_ == FEVectorPiola);
     
@@ -368,9 +371,9 @@ void FEValuesBase<dim,spacedim>::fill_vec_piola_data(const ElementValues<spacedi
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_tensor_data(const ElementValues<spacedim> &elm_values,
-                                                  const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_tensor_data(const ElementValues<spacedim> &elm_values,
+                                              const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe_type_ == FETensor);
     
@@ -400,8 +403,8 @@ void FEValuesBase<dim,spacedim>::fill_tensor_data(const ElementValues<spacedim> 
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_system_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_system_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data)
 {
     ASSERT_DBG(fe_type_ == FEMixedSystem);
     
@@ -457,8 +460,8 @@ void FEValuesBase<dim,spacedim>::fill_system_data(const ElementValues<spacedim> 
 }
 
 
-template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::fill_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data)
+template<unsigned int spacedim>
+void FEValuesBase<spacedim>::fill_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data)
 {
     switch (fe_type_) {
         case FEScalar:
@@ -496,7 +499,7 @@ FEValues<dim,spacedim>::FEValues(
          Quadrature &q,
          FiniteElement<dim> &_fe,
          UpdateFlags _flags)
-: FEValuesBase<dim, spacedim>(),
+: FEValuesBase<spacedim>(),
   fe_data(nullptr)
 {
     if (dim == 0) return; // avoid unnecessary allocation of dummy 0 dimensional objects
@@ -566,7 +569,7 @@ FESideValues<dim,spacedim>::FESideValues(
                                  Quadrature & _sub_quadrature,
                                  FiniteElement<dim> & _fe,
                                  const UpdateFlags _flags)
-: FEValuesBase<dim,spacedim>()
+: FEValuesBase<spacedim>()
 {
     ASSERT_DBG( _sub_quadrature.dim() + 1 == dim );
     this->allocate( _sub_quadrature.size(), _fe, _flags);
@@ -627,10 +630,7 @@ void FESideValues<dim,spacedim>::reinit(const Side &cell_side)
 
 
 
-template class FEValuesBase<0,3>;
-template class FEValuesBase<1,3>;
-template class FEValuesBase<2,3>;
-template class FEValuesBase<3,3>;
+template class FEValuesBase<3>;
 
 template class FEValues<0,3>;
 template class FEValues<1,3>;

--- a/src/fem/fe_values.cc
+++ b/src/fem/fe_values.cc
@@ -64,12 +64,12 @@ FEValuesBase<dim,spacedim>::FEInternalData::FEInternalData(const FEInternalData 
 
 
 template<unsigned int dim, unsigned int spacedim>
-void FEValuesBase<dim,spacedim>::ViewsCache::initialize(FEValuesBase<dim,spacedim> &fv)
+void FEValuesBase<dim,spacedim>::ViewsCache::initialize(const FEValuesBase<dim,spacedim> &fv, const FiniteElement<dim> &fe)
 {
   scalars.clear();
   vectors.clear();
   tensors.clear();
-  switch (fv.get_fe()->type_) {
+  switch (fe.type_) {
     case FEType::FEScalar:
       scalars.push_back(FEValuesViews::Scalar<dim,spacedim>(fv, 0));
       break;
@@ -82,7 +82,7 @@ void FEValuesBase<dim,spacedim>::ViewsCache::initialize(FEValuesBase<dim,spacedi
       tensors.push_back(FEValuesViews::Tensor<dim,spacedim>(fv, 0));
       break;
     case FEType::FEMixedSystem:
-      FESystem<dim> *fe_sys = dynamic_cast<FESystem<dim>*>(fv.get_fe());
+      const FESystem<dim> *fe_sys = dynamic_cast<const FESystem<dim>*>(&fe);
       ASSERT_DBG(fe_sys != nullptr).error("Mixed system must be represented by FESystem.");
       
       // Loop through sub-elements and add views according to their types.
@@ -158,7 +158,7 @@ void FEValuesBase<dim,spacedim>::allocate(
     if (update_flags & update_gradients)
         shape_gradients.resize(n_points_, vector<arma::vec::fixed<spacedim> >(fe->n_dofs()*n_components_));
     
-    views_cache_.initialize(*this);
+    views_cache_.initialize(*this, _fe);
 }
 
 

--- a/src/fem/fe_values.cc
+++ b/src/fem/fe_values.cc
@@ -536,9 +536,9 @@ FEValues<dim,spacedim>::~FEValues()
 
 
 template<unsigned int dim,unsigned int spacedim>
-void FEValues<dim,spacedim>::reinit(const DHCellAccessor &cell)
+void FEValues<dim,spacedim>::reinit(const ElementAccessor<spacedim> &cell)
 {
-	OLD_ASSERT_EQUAL( dim, cell.dim() );
+	ASSERT_EQ_DBG( dim, cell.dim() );
     
     if (!this->elm_values->cell().is_valid() ||
         this->elm_values->cell() != cell)
@@ -612,11 +612,11 @@ FESideValues<dim,spacedim>::~FESideValues()
 
 
 template<unsigned int dim,unsigned int spacedim>
-void FESideValues<dim,spacedim>::reinit(const DHCellSide &cell_side)
+void FESideValues<dim,spacedim>::reinit(const Side &cell_side)
 {
     ASSERT_EQ_DBG( dim, cell_side.dim() );
     
-    if (!this->elm_values->side().is_valid() || 
+    if (!this->elm_values->side().valid() || 
         this->elm_values->side() != cell_side)
     {
         this->elm_values->reinit(cell_side);

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -46,58 +46,10 @@ template<unsigned int dim> class FiniteElement;
 
 
 /**
- * @brief Abstract base class with certain methods independent of the template parameter @p dim.
- */
-template<unsigned int spacedim = 3>
-class FEValuesSpaceBase
-{
-public:
-    virtual ~FEValuesSpaceBase() {}
-    /**
-     * @brief Return the value of the @p function_no-th shape function at
-     * the @p point_no-th quadrature point.
-     *
-     * @param function_no Number of the shape function.
-     * @param point_no Number of the quadrature point.
-     */
-    virtual double shape_value(const unsigned int function_no, const unsigned int point_no) = 0;
-
-    /**
-     * @brief Return the gradient of the @p function_no-th shape function at
-     * the @p point_no-th quadrature point.
-     *
-     * @param function_no Number of the shape function.
-     * @param point_no Number of the quadrature point.
-     */
-    virtual arma::vec::fixed<spacedim> shape_grad(const unsigned int function_no, const unsigned int point_no) = 0;
-
-    /**
-     * @brief Return the product of Jacobian determinant and the quadrature
-     * weight at given quadrature point.
-     *
-     * @param point_no Number of the quadrature point.
-     */
-    virtual double JxW(const unsigned int point_no) = 0;
-
-    /**
-     * @brief Returns the normal vector to a side at given quadrature point.
-     *
-     * @param point_no Number of the quadrature point.
-     */
-    virtual arma::vec::fixed<spacedim> normal_vector(unsigned int point_no) = 0;
-
-    /**
-     * @brief Returns the number of shape functions.
-     */
-    virtual unsigned int n_dofs() const = 0;
-
-};
-
-/**
  * @brief Base class for FEValues and FESideValues
  */
 template<unsigned int spacedim = 3>
-class FEValuesBase : public FEValuesSpaceBase<spacedim>
+class FEValuesBase
 {
 private:
   
@@ -145,7 +97,7 @@ public:
      * @param function_no Number of the shape function.
      * @param point_no Number of the quadrature point.
      */
-    double shape_value(const unsigned int function_no, const unsigned int point_no) override;
+    double shape_value(const unsigned int function_no, const unsigned int point_no);
 
 
     /**
@@ -155,7 +107,7 @@ public:
      * @param function_no Number of the shape function.
      * @param point_no Number of the quadrature point.
      */
-    arma::vec::fixed<spacedim> shape_grad(const unsigned int function_no, const unsigned int point_no) override;
+    arma::vec::fixed<spacedim> shape_grad(const unsigned int function_no, const unsigned int point_no);
 
     /**
      * @brief Return the value of the @p function_no-th shape function at
@@ -203,7 +155,7 @@ public:
      *
      * @param point_no Number of the quadrature point.
      */
-    inline double JxW(const unsigned int point_no) override
+    inline double JxW(const unsigned int point_no)
     {
         ASSERT_LT_DBG(point_no, n_points_);
         // TODO: This is temporary solution to distinguish JxW on element and side_JxW on side.
@@ -237,7 +189,7 @@ public:
      *
      * @param point_no Number of the quadrature point.
      */
-	inline arma::vec::fixed<spacedim> normal_vector(unsigned int point_no) override
+	inline arma::vec::fixed<spacedim> normal_vector(unsigned int point_no)
 	{
         ASSERT_LT_DBG(point_no, n_points_);
 	    return elm_values->normal_vector(point_no);
@@ -282,7 +234,7 @@ public:
     /**
      * @brief Returns the number of shape functions.
      */
-    inline unsigned int n_dofs() const override
+    inline unsigned int n_dofs() const
     {
         return n_dofs_;
     }

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -454,7 +454,7 @@ public:
      *
      * @param cell The actual cell.
      */
-    void reinit(const DHCellAccessor &cell);
+    void reinit(const ElementAccessor<spacedim> &cell);
     
     
     
@@ -514,7 +514,7 @@ public:
 	 *
 	 * @param cell_side Accessor to cell side.
 	 */
-    void reinit(const DHCellSide &cell_side);
+    void reinit(const Side &cell_side);
 
 
 private:

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -490,7 +490,7 @@ std::vector<FEValues<3>> mixed_fe_values(
  * @param spacedim Dimension of the Euclidean space where the actual
  *                 cell lives.
  */
-template<unsigned int dim, unsigned int spacedim>
+template<unsigned int spacedim>
 class FESideValues : public FEValuesBase<spacedim>
 {
 
@@ -506,7 +506,10 @@ public:
      * @param _fe The finite element.
      * @param flags The update flags.
      */
-    FESideValues(Quadrature &_sub_quadrature,
+    FESideValues() : FEValuesBase<spacedim>() {}
+    
+    template<unsigned int dim>
+    void initialize(Quadrature &_sub_quadrature,
              FiniteElement<dim> &_fe,
              UpdateFlags flags);
 
@@ -527,7 +530,7 @@ private:
     void fill_fe_side_values();
     
     /// Internal data (shape functions on reference element) for all sides and permuted quadrature points.
-    typename FEValuesBase<spacedim>::FEInternalData *side_fe_data[RefElement<dim>::n_sides][RefElement<dim>::n_side_permutations];
+    std::vector<std::vector<typename FEValuesBase<spacedim>::FEInternalData*>> side_fe_data;
     
 };
 

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -73,8 +73,20 @@ private:
   
 public:
 
-    /// Default constructor.
+    /// Default constructor with postponed initialization.
     FEValues();
+
+
+    /// Constructor with initialization of data structures
+    /// (see initialize() for description of parameters).
+    template<unsigned int DIM>
+    FEValues(Quadrature &_quadrature,
+             FiniteElement<DIM> &_fe,
+             UpdateFlags _flags)
+    : FEValues()
+    {
+        initialize(_quadrature, _fe, _flags);
+    }
 
 
     /// Correct deallocation of objects created by 'initialize' methods.

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -384,7 +384,7 @@ protected:
     ElementValues<spacedim> *elm_values;
     
     /// Vector of FEValues for sub-elements of FESystem.
-    std::vector<std::shared_ptr<FEValues<spacedim> > > fe_values_vec;
+    std::vector<FEValues<spacedim>> fe_values_vec;
     
     /// Number of components of the FE.
     unsigned int n_components_;

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -111,7 +111,7 @@ private:
     vector<FEValuesViews::Vector<dim,spacedim> > vectors;
     vector<FEValuesViews::Tensor<dim,spacedim> > tensors;
     
-    void initialize(FEValuesBase &fv);
+    void initialize(const FEValuesBase &fv, const FiniteElement<dim> &fe);
   };
   
 public:
@@ -296,13 +296,6 @@ public:
     }
 
 
-    /**
-     * @brief Returns the finite element in use.
-     */
-    inline FiniteElement<dim> * get_fe() const
-    {
-        return fe;
-    }
     
 
 protected:

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -99,7 +99,7 @@ public:
 /**
  * @brief Base class for FEValues and FESideValues
  */
-template<unsigned int dim, unsigned int spacedim = 3>
+template<unsigned int spacedim = 3>
 class FEValuesBase : public FEValuesSpaceBase<spacedim>
 {
 private:
@@ -107,10 +107,11 @@ private:
   // internal structure that stores all possible views
   // for scalar and vector-valued components of the FE
   struct ViewsCache {
-    vector<FEValuesViews::Scalar<dim,spacedim> > scalars;
-    vector<FEValuesViews::Vector<dim,spacedim> > vectors;
-    vector<FEValuesViews::Tensor<dim,spacedim> > tensors;
+    vector<FEValuesViews::Scalar<spacedim> > scalars;
+    vector<FEValuesViews::Vector<spacedim> > vectors;
+    vector<FEValuesViews::Tensor<spacedim> > tensors;
     
+    template<unsigned int dim>
     void initialize(const FEValuesBase &fv, const FiniteElement<dim> &fe);
   };
   
@@ -135,6 +136,7 @@ public:
      * @param _fe The finite element.
      * @param flags The update flags.
      */
+    template<unsigned int dim>
     void allocate(unsigned int n_points,
             FiniteElement<dim> &_fe,
             UpdateFlags flags);
@@ -248,7 +250,7 @@ public:
      * @brief Accessor to scalar values of multicomponent FE.
      * @param i Index of scalar component.
      */
-	const FEValuesViews::Scalar<dim,spacedim> &scalar_view(unsigned int i) const
+	const FEValuesViews::Scalar<spacedim> &scalar_view(unsigned int i) const
 	{
       ASSERT_LT_DBG(i, views_cache_.scalars.size());
       return views_cache_.scalars[i];
@@ -258,7 +260,7 @@ public:
      * @brief Accessor to vector values of multicomponent FE.
      * @param i Index of first vector component.
      */
-    const FEValuesViews::Vector<dim,spacedim> &vector_view(unsigned int i) const
+    const FEValuesViews::Vector<spacedim> &vector_view(unsigned int i) const
     {
       ASSERT_LT_DBG(i, views_cache_.vectors.size());
       return views_cache_.vectors[i];
@@ -268,7 +270,7 @@ public:
      * @brief Accessor to tensor values of multicomponent FE.
      * @param i Index of first tensor component.
      */
-    const FEValuesViews::Tensor<dim,spacedim> &tensor_view(unsigned int i) const
+    const FEValuesViews::Tensor<spacedim> &tensor_view(unsigned int i) const
     {
       ASSERT_LT_DBG(i, views_cache_.tensors.size());
       return views_cache_.tensors[i];
@@ -339,6 +341,7 @@ protected:
 
     
     /// Precompute finite element data on reference element.
+    template<unsigned int dim>
     FEInternalData *init_fe_data(const FiniteElement<dim> &fe, const Quadrature &q);
     
     /**
@@ -400,7 +403,7 @@ protected:
     ElementValues<spacedim> *elm_values;
     
     /// Vector of FEValues for sub-elements of FESystem.
-    std::vector<std::shared_ptr<FEValuesBase<dim,spacedim> > > fe_values_vec;
+    std::vector<std::shared_ptr<FEValuesBase<spacedim> > > fe_values_vec;
     
     /// Number of components of the FE.
     unsigned int n_components_;
@@ -424,7 +427,7 @@ protected:
  *                 cell lives.
  */
 template<unsigned int dim, unsigned int spacedim = 3>
-class FEValues : public FEValuesBase<dim,spacedim>
+class FEValues : public FEValuesBase<spacedim>
 {
 public:
 
@@ -461,7 +464,7 @@ private:
     void fill_fe_values();
     
     /// Precomputed finite element data.
-    typename FEValuesBase<dim,spacedim>::FEInternalData *fe_data;
+    typename FEValuesBase<spacedim>::FEInternalData *fe_data;
     
 
 };
@@ -485,7 +488,7 @@ MixedPtr<FEValues> mixed_fe_values(
  *                 cell lives.
  */
 template<unsigned int dim, unsigned int spacedim>
-class FESideValues : public FEValuesBase<dim,spacedim>
+class FESideValues : public FEValuesBase<spacedim>
 {
 
 public:
@@ -521,7 +524,7 @@ private:
     void fill_fe_side_values();
     
     /// Internal data (shape functions on reference element) for all sides and permuted quadrature points.
-    typename FEValuesBase<dim,spacedim>::FEInternalData *side_fe_data[RefElement<dim>::n_sides][RefElement<dim>::n_side_permutations];
+    typename FEValuesBase<spacedim>::FEInternalData *side_fe_data[RefElement<dim>::n_sides][RefElement<dim>::n_side_permutations];
     
 };
 

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -92,7 +92,7 @@ public:
     /**
      * @brief Returns the number of shape functions.
      */
-    virtual unsigned int n_dofs() = 0;
+    virtual unsigned int n_dofs() const = 0;
 
 };
 
@@ -284,13 +284,13 @@ public:
     /**
      * @brief Returns the number of quadrature points.
      */
-    inline unsigned int n_points()
+    inline unsigned int n_points() const
     { return n_points_; }
 
     /**
      * @brief Returns the number of shape functions.
      */
-    inline unsigned int n_dofs() override
+    inline unsigned int n_dofs() const override
     {
         return fe->n_dofs();
     }

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -140,13 +140,6 @@ public:
             UpdateFlags flags);
     
     /**
-     * @brief Determine quantities to be recomputed on each cell.
-     *
-     * @param flags Flags that indicate what has to be recomputed.
-     */
-    UpdateFlags update_each(UpdateFlags flags);
-
-    /**
      * @brief Return the value of the @p function_no-th shape function at
      * the @p point_no-th quadrature point.
      *
@@ -292,7 +285,7 @@ public:
      */
     inline unsigned int n_dofs() const override
     {
-        return fe->n_dofs();
+        return n_dofs_;
     }
 
 
@@ -346,7 +339,7 @@ protected:
 
     
     /// Precompute finite element data on reference element.
-    FEInternalData *init_fe_data(const Quadrature &q);
+    FEInternalData *init_fe_data(const FiniteElement<dim> &fe, const Quadrature &q);
     
     /**
      * @brief Computes the shape function values and gradients on the actual cell
@@ -378,8 +371,20 @@ protected:
     /// Number of integration points.
     unsigned int n_points_;
 
-    /// The used finite element.
-    FiniteElement<dim> *fe;
+    /// Number of finite element dofs.
+    unsigned int n_dofs_;
+
+    /// Type of finite element (scalar, vector, tensor).
+    FEType fe_type_;
+
+    /// Dof indices of FESystem sub-elements.
+    std::vector<std::vector<unsigned int>> fe_sys_dofs_;
+
+    /// Numbers of components of FESystem sub-elements in reference space.
+    std::vector<unsigned int> fe_sys_n_components_;
+
+    /// Numbers of components of FESystem sub-elements in real space.
+    std::vector<unsigned int> fe_sys_n_space_components_;
     
     /// Shape functions evaluated at the quadrature points.
     std::vector<std::vector<double> > shape_values;

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -45,9 +45,6 @@ template<unsigned int dim> class FiniteElement;
 
 
 
-
-
-
 /**
  * @brief Abstract base class with certain methods independent of the template parameter @p dim.
  */
@@ -104,16 +101,16 @@ class FEValuesBase : public FEValuesSpaceBase<spacedim>
 {
 private:
   
-  // internal structure that stores all possible views
-  // for scalar and vector-valued components of the FE
-  struct ViewsCache {
-    vector<FEValuesViews::Scalar<spacedim> > scalars;
-    vector<FEValuesViews::Vector<spacedim> > vectors;
-    vector<FEValuesViews::Tensor<spacedim> > tensors;
+    // internal structure that stores all possible views
+    // for scalar and vector-valued components of the FE
+    struct ViewsCache {
+        vector<FEValuesViews::Scalar<spacedim> > scalars;
+        vector<FEValuesViews::Vector<spacedim> > vectors;
+        vector<FEValuesViews::Tensor<spacedim> > tensors;
     
-    template<unsigned int dim>
-    void initialize(const FEValuesBase &fv, const FiniteElement<dim> &fe);
-  };
+        template<unsigned int dim>
+        void initialize(const FEValuesBase &fv, const FiniteElement<dim> &fe);
+    };
   
 public:
 
@@ -290,7 +287,9 @@ public:
         return n_dofs_;
     }
 
-
+    /// Return dimension of reference space.
+    inline unsigned int dm() const
+    { return dim_; }
     
 
 protected:
@@ -371,6 +370,9 @@ protected:
     void fill_system_data(const ElementValues<spacedim> &elm_values, const FEInternalData &fe_data);
     
 
+    /// Dimension of reference space.
+    int dim_;
+
     /// Number of integration points.
     unsigned int n_points_;
 
@@ -426,13 +428,14 @@ protected:
  * @param spacedim Dimension of the Euclidean space where the actual
  *                 cell lives.
  */
-template<unsigned int dim, unsigned int spacedim = 3>
+template<unsigned int spacedim = 3>
 class FEValues : public FEValuesBase<spacedim>
 {
 public:
 
     /// Default invalid constructor.
-	FEValues() : fe_data(nullptr) {}
+	FEValues()
+    : FEValuesBase<spacedim>(), fe_data(nullptr) {}
 
 	/**
 	 * @brief Constructor.
@@ -444,9 +447,10 @@ public:
 	 * @param _fe The finite element.
 	 * @param _flags The update flags.
 	 */
-    FEValues(Quadrature &_quadrature,
-             FiniteElement<dim> &_fe,
-             UpdateFlags _flags);
+    template<unsigned int dim>
+    void initialize(Quadrature &_quadrature,
+                    FiniteElement<dim> &_fe,
+                    UpdateFlags _flags);
     
     ~FEValues();
 
@@ -466,11 +470,10 @@ private:
     /// Precomputed finite element data.
     typename FEValuesBase<spacedim>::FEInternalData *fe_data;
     
-
 };
 
 
-MixedPtr<FEValues> mixed_fe_values(
+std::vector<FEValues<3>> mixed_fe_values(
         QGauss::array &quadrature,
         MixedPtr<FiniteElement> fe,
         UpdateFlags flags);

--- a/src/fem/fe_values.hh
+++ b/src/fem/fe_values.hh
@@ -67,8 +67,8 @@ private:
         vector<FEValuesViews::Vector<spacedim> > vectors;
         vector<FEValuesViews::Tensor<spacedim> > tensors;
     
-        template<unsigned int dim>
-        void initialize(const FEValues &fv, const FiniteElement<dim> &fe);
+        template<unsigned int DIM>
+        void initialize(const FEValues &fv, const FiniteElement<DIM> &fe);
     };
   
 public:
@@ -88,9 +88,9 @@ public:
      * @param _fe         The finite element.
      * @param flags       The update flags.
      */
-    template<unsigned int dim>
+    template<unsigned int DIM>
     void allocate(unsigned int n_points,
-                  FiniteElement<dim> &_fe,
+                  FiniteElement<DIM> &_fe,
                   UpdateFlags flags);
     
     /**
@@ -101,9 +101,9 @@ public:
 	 * @param _fe The finite element.
 	 * @param _flags The update flags.
 	 */
-    template<unsigned int dim>
+    template<unsigned int DIM>
     void initialize(Quadrature &_quadrature,
-                    FiniteElement<dim> &_fe,
+                    FiniteElement<DIM> &_fe,
                     UpdateFlags _flags);
     
     /**
@@ -168,7 +168,7 @@ public:
     /**
      * @brief Return the relative volume change of the cell (Jacobian determinant).
      *
-     * If dim==spacedim then the sign may be negative, otherwise the
+     * If dim_==spacedim then the sign may be negative, otherwise the
      * result is a positive number.
      *
      * @param point_no Number of the quadrature point.
@@ -270,7 +270,7 @@ public:
     }
 
     /// Return dimension of reference space.
-    inline unsigned int dm() const
+    inline unsigned int dim() const
     { return dim_; }
     
 
@@ -303,7 +303,7 @@ protected:
          *
          * Dimensions:   (no. of quadrature points)
          *             x (no. of dofs)
-         *             x ((dim of. ref. cell)x(no. of components in ref. cell))
+         *             x ((dim_ of. ref. cell)x(no. of components in ref. cell))
          */
         std::vector<std::vector<arma::mat> > ref_shape_grads;
         
@@ -319,8 +319,8 @@ protected:
 
     
     /// Precompute finite element data on reference element.
-    template<unsigned int dim>
-    FEInternalData *init_fe_data(const FiniteElement<dim> &fe, const Quadrature &q);
+    template<unsigned int DIM>
+    FEInternalData *init_fe_data(const FiniteElement<DIM> &fe, const Quadrature &q);
     
     /**
      * @brief Computes the shape function values and gradients on the actual cell

--- a/src/fem/fe_values_views.cc
+++ b/src/fem/fe_values_views.cc
@@ -41,7 +41,7 @@ arma::vec::fixed<spacedim> FEValuesViews::Scalar<dim,spacedim>::grad(unsigned in
 }
 
 template<unsigned int dim, unsigned int spacedim>
-FEValuesBase<dim,spacedim> &FEValuesViews::Scalar<dim,spacedim>::base() const
+const FEValuesBase<dim,spacedim> &FEValuesViews::Scalar<dim,spacedim>::base() const
 { return fe_values_; }
   
 
@@ -90,7 +90,7 @@ double FEValuesViews::Vector<dim,spacedim>::divergence(unsigned int function_no,
 }
 
 template<unsigned int dim, unsigned int spacedim>
-FEValuesBase<dim,spacedim> &FEValuesViews::Vector<dim,spacedim>::base() const
+const FEValuesBase<dim,spacedim> &FEValuesViews::Vector<dim,spacedim>::base() const
 { return fe_values_; }
 
 
@@ -134,7 +134,7 @@ arma::vec::fixed<spacedim> FEValuesViews::Tensor<dim,spacedim>::divergence(unsig
 }
 
 template<unsigned int dim, unsigned int spacedim>
-FEValuesBase<dim,spacedim> &FEValuesViews::Tensor<dim,spacedim>::base() const
+const FEValuesBase<dim,spacedim> &FEValuesViews::Tensor<dim,spacedim>::base() const
 { return fe_values_; }
   
 

--- a/src/fem/fe_values_views.cc
+++ b/src/fem/fe_values_views.cc
@@ -24,31 +24,31 @@
 
 using namespace FEValuesViews;
 
-template<unsigned int dim, unsigned int spacedim>
-double FEValuesViews::Scalar<dim,spacedim>::value(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+double FEValuesViews::Scalar<spacedim>::value(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
   return fe_values_.shape_value_component(function_no, point_no, component_);
 }
 
-template<unsigned int dim, unsigned int spacedim>
-arma::vec::fixed<spacedim> FEValuesViews::Scalar<dim,spacedim>::grad(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+arma::vec::fixed<spacedim> FEValuesViews::Scalar<spacedim>::grad(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
   return fe_values_.shape_grad_component(function_no, point_no, component_);
 }
 
-template<unsigned int dim, unsigned int spacedim>
-const FEValuesBase<dim,spacedim> &FEValuesViews::Scalar<dim,spacedim>::base() const
+template<unsigned int spacedim>
+const FEValuesBase<spacedim> &FEValuesViews::Scalar<spacedim>::base() const
 { return fe_values_; }
   
 
 
 
-template<unsigned int dim, unsigned int spacedim>
-arma::vec::fixed<spacedim> FEValuesViews::Vector<dim,spacedim>::value(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+arma::vec::fixed<spacedim> FEValuesViews::Vector<spacedim>::value(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
@@ -58,8 +58,8 @@ arma::vec::fixed<spacedim> FEValuesViews::Vector<dim,spacedim>::value(unsigned i
   return v;
 }
 
-template<unsigned int dim, unsigned int spacedim>
-arma::mat::fixed<spacedim,spacedim> FEValuesViews::Vector<dim,spacedim>::grad(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+arma::mat::fixed<spacedim,spacedim> FEValuesViews::Vector<spacedim>::grad(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
@@ -69,8 +69,8 @@ arma::mat::fixed<spacedim,spacedim> FEValuesViews::Vector<dim,spacedim>::grad(un
   return g.t();
 }
 
-template<unsigned int dim, unsigned int spacedim>
-arma::mat::fixed<spacedim,spacedim> FEValuesViews::Vector<dim,spacedim>::sym_grad(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+arma::mat::fixed<spacedim,spacedim> FEValuesViews::Vector<spacedim>::sym_grad(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
@@ -78,8 +78,8 @@ arma::mat::fixed<spacedim,spacedim> FEValuesViews::Vector<dim,spacedim>::sym_gra
   return 0.5*(g+trans(g));
 }
 
-template<unsigned int dim, unsigned int spacedim>
-double FEValuesViews::Vector<dim,spacedim>::divergence(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+double FEValuesViews::Vector<spacedim>::divergence(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
@@ -89,14 +89,14 @@ double FEValuesViews::Vector<dim,spacedim>::divergence(unsigned int function_no,
   return div;
 }
 
-template<unsigned int dim, unsigned int spacedim>
-const FEValuesBase<dim,spacedim> &FEValuesViews::Vector<dim,spacedim>::base() const
+template<unsigned int spacedim>
+const FEValuesBase<spacedim> &FEValuesViews::Vector<spacedim>::base() const
 { return fe_values_; }
 
 
 
-template<unsigned int dim, unsigned int spacedim>
-arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<dim,spacedim>::value(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<spacedim>::value(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
@@ -106,8 +106,8 @@ arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<dim,spacedim>::value(u
   return v;
 }
 
-template<unsigned int dim, unsigned int spacedim>
-arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<dim,spacedim>::derivative(
+template<unsigned int spacedim>
+arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<spacedim>::derivative(
     unsigned int variable_no,
     unsigned int function_no, 
     unsigned int point_no) const
@@ -121,8 +121,8 @@ arma::mat::fixed<spacedim,spacedim> FEValuesViews::Tensor<dim,spacedim>::derivat
   return g;
 }
 
-template<unsigned int dim, unsigned int spacedim>
-arma::vec::fixed<spacedim> FEValuesViews::Tensor<dim,spacedim>::divergence(unsigned int function_no, unsigned int point_no) const
+template<unsigned int spacedim>
+arma::vec::fixed<spacedim> FEValuesViews::Tensor<spacedim>::divergence(unsigned int function_no, unsigned int point_no) const
 {
   ASSERT_LT_DBG( function_no, fe_values_.n_dofs() );
   ASSERT_LT_DBG( point_no, fe_values_.n_points() );
@@ -133,27 +133,16 @@ arma::vec::fixed<spacedim> FEValuesViews::Tensor<dim,spacedim>::divergence(unsig
   return div;
 }
 
-template<unsigned int dim, unsigned int spacedim>
-const FEValuesBase<dim,spacedim> &FEValuesViews::Tensor<dim,spacedim>::base() const
+template<unsigned int spacedim>
+const FEValuesBase<spacedim> &FEValuesViews::Tensor<spacedim>::base() const
 { return fe_values_; }
   
 
 
 
 
-template class FEValuesViews::Scalar<0,3>;
-template class FEValuesViews::Scalar<1,3>;
-template class FEValuesViews::Scalar<2,3>;
-template class FEValuesViews::Scalar<3,3>;
-
-template class FEValuesViews::Vector<0,3>;
-template class FEValuesViews::Vector<1,3>;
-template class FEValuesViews::Vector<2,3>;
-template class FEValuesViews::Vector<3,3>;
-
-template class FEValuesViews::Tensor<0,3>;
-template class FEValuesViews::Tensor<1,3>;
-template class FEValuesViews::Tensor<2,3>;
-template class FEValuesViews::Tensor<3,3>;
+template class FEValuesViews::Scalar<3>;
+template class FEValuesViews::Vector<3>;
+template class FEValuesViews::Tensor<3>;
 
 

--- a/src/fem/fe_values_views.cc
+++ b/src/fem/fe_values_views.cc
@@ -41,7 +41,7 @@ arma::vec::fixed<spacedim> FEValuesViews::Scalar<spacedim>::grad(unsigned int fu
 }
 
 template<unsigned int spacedim>
-const FEValuesBase<spacedim> &FEValuesViews::Scalar<spacedim>::base() const
+const FEValues<spacedim> &FEValuesViews::Scalar<spacedim>::base() const
 { return fe_values_; }
   
 
@@ -90,7 +90,7 @@ double FEValuesViews::Vector<spacedim>::divergence(unsigned int function_no, uns
 }
 
 template<unsigned int spacedim>
-const FEValuesBase<spacedim> &FEValuesViews::Vector<spacedim>::base() const
+const FEValues<spacedim> &FEValuesViews::Vector<spacedim>::base() const
 { return fe_values_; }
 
 
@@ -134,7 +134,7 @@ arma::vec::fixed<spacedim> FEValuesViews::Tensor<spacedim>::divergence(unsigned 
 }
 
 template<unsigned int spacedim>
-const FEValuesBase<spacedim> &FEValuesViews::Tensor<spacedim>::base() const
+const FEValues<spacedim> &FEValuesViews::Tensor<spacedim>::base() const
 { return fe_values_; }
   
 

--- a/src/fem/fe_values_views.hh
+++ b/src/fem/fe_values_views.hh
@@ -39,7 +39,7 @@ namespace FEValuesViews {
     
   public:
     
-    Scalar(FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+    Scalar(const FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         component_(component)
     {};
@@ -59,12 +59,12 @@ namespace FEValuesViews {
     arma::vec::fixed<spacedim> grad(unsigned int function_no, unsigned int point_no) const;
     
     /// Returns the FEValuesBase class.
-    FEValuesBase<dim,spacedim> &base() const;
+    const FEValuesBase<dim,spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    FEValuesBase<dim,spacedim> &fe_values_;
+    const FEValuesBase<dim,spacedim> &fe_values_;
     
     /// Index of the scalar component.
     unsigned int component_;
@@ -76,7 +76,7 @@ namespace FEValuesViews {
     
   public:
     
-    Vector(FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+    Vector(const FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         first_vector_component_(component)
     {};
@@ -110,12 +110,12 @@ namespace FEValuesViews {
     double divergence(unsigned int function_no, unsigned int point_no) const;
     
     /// Returns the FEValuesBase class.
-    FEValuesBase<dim,spacedim> &base() const;
+    const FEValuesBase<dim,spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    FEValuesBase<dim,spacedim> &fe_values_;
+    const FEValuesBase<dim,spacedim> &fe_values_;
     
     /// Index of the first component of the vector.
     unsigned int first_vector_component_;
@@ -127,7 +127,7 @@ namespace FEValuesViews {
       
   public:
     
-    Tensor(FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+    Tensor(const FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         first_tensor_component_(component)
     {};
@@ -162,12 +162,12 @@ namespace FEValuesViews {
     arma::vec::fixed<spacedim> divergence(unsigned int function_no, unsigned int point_no) const;
     
     /// Returns the FEValuesBase class.
-    FEValuesBase<dim,spacedim> &base() const;
+    const FEValuesBase<dim,spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    FEValuesBase<dim,spacedim> &fe_values_;
+    const FEValuesBase<dim,spacedim> &fe_values_;
     
     /// Index of the first component of the vector.
     unsigned int first_tensor_component_;

--- a/src/fem/fe_values_views.hh
+++ b/src/fem/fe_values_views.hh
@@ -22,7 +22,7 @@
 #include <vector>
 #include <armadillo>
 
-template<unsigned int dim, unsigned int spacedim> class FEValuesBase;
+template<unsigned int spacedim> class FEValuesBase;
 
 
 
@@ -34,12 +34,12 @@ template<unsigned int dim, unsigned int spacedim> class FEValuesBase;
  */
 namespace FEValuesViews {
 
-  template<unsigned int dim, unsigned int spacedim>
+  template<unsigned int spacedim = 3>
   class Scalar {
     
   public:
     
-    Scalar(const FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+    Scalar(const FEValuesBase<spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         component_(component)
     {};
@@ -59,24 +59,24 @@ namespace FEValuesViews {
     arma::vec::fixed<spacedim> grad(unsigned int function_no, unsigned int point_no) const;
     
     /// Returns the FEValuesBase class.
-    const FEValuesBase<dim,spacedim> &base() const;
+    const FEValuesBase<spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    const FEValuesBase<dim,spacedim> &fe_values_;
+    const FEValuesBase<spacedim> &fe_values_;
     
     /// Index of the scalar component.
     unsigned int component_;
   };
 
 
-  template<unsigned int dim, unsigned int spacedim>
+  template<unsigned int spacedim = 3>
   class Vector {
     
   public:
     
-    Vector(const FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+    Vector(const FEValuesBase<spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         first_vector_component_(component)
     {};
@@ -110,24 +110,24 @@ namespace FEValuesViews {
     double divergence(unsigned int function_no, unsigned int point_no) const;
     
     /// Returns the FEValuesBase class.
-    const FEValuesBase<dim,spacedim> &base() const;
+    const FEValuesBase<spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    const FEValuesBase<dim,spacedim> &fe_values_;
+    const FEValuesBase<spacedim> &fe_values_;
     
     /// Index of the first component of the vector.
     unsigned int first_vector_component_;
   };
   
   
-  template<unsigned int dim, unsigned int spacedim>
+  template<unsigned int spacedim = 3>
   class Tensor {
       
   public:
     
-    Tensor(const FEValuesBase<dim,spacedim> &fe_values, unsigned int component)
+    Tensor(const FEValuesBase<spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         first_tensor_component_(component)
     {};
@@ -162,12 +162,12 @@ namespace FEValuesViews {
     arma::vec::fixed<spacedim> divergence(unsigned int function_no, unsigned int point_no) const;
     
     /// Returns the FEValuesBase class.
-    const FEValuesBase<dim,spacedim> &base() const;
+    const FEValuesBase<spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    const FEValuesBase<dim,spacedim> &fe_values_;
+    const FEValuesBase<spacedim> &fe_values_;
     
     /// Index of the first component of the vector.
     unsigned int first_tensor_component_;

--- a/src/fem/fe_values_views.hh
+++ b/src/fem/fe_values_views.hh
@@ -22,7 +22,7 @@
 #include <vector>
 #include <armadillo>
 
-template<unsigned int spacedim> class FEValuesBase;
+template<unsigned int spacedim> class FEValues;
 
 
 
@@ -39,7 +39,7 @@ namespace FEValuesViews {
     
   public:
     
-    Scalar(const FEValuesBase<spacedim> &fe_values, unsigned int component)
+    Scalar(const FEValues<spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         component_(component)
     {};
@@ -58,13 +58,13 @@ namespace FEValuesViews {
      */
     arma::vec::fixed<spacedim> grad(unsigned int function_no, unsigned int point_no) const;
     
-    /// Returns the FEValuesBase class.
-    const FEValuesBase<spacedim> &base() const;
+    /// Returns the FEValues class.
+    const FEValues<spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    const FEValuesBase<spacedim> &fe_values_;
+    const FEValues<spacedim> &fe_values_;
     
     /// Index of the scalar component.
     unsigned int component_;
@@ -76,7 +76,7 @@ namespace FEValuesViews {
     
   public:
     
-    Vector(const FEValuesBase<spacedim> &fe_values, unsigned int component)
+    Vector(const FEValues<spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         first_vector_component_(component)
     {};
@@ -109,13 +109,13 @@ namespace FEValuesViews {
      */
     double divergence(unsigned int function_no, unsigned int point_no) const;
     
-    /// Returns the FEValuesBase class.
-    const FEValuesBase<spacedim> &base() const;
+    /// Returns the FEValues class.
+    const FEValues<spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    const FEValuesBase<spacedim> &fe_values_;
+    const FEValues<spacedim> &fe_values_;
     
     /// Index of the first component of the vector.
     unsigned int first_vector_component_;
@@ -127,7 +127,7 @@ namespace FEValuesViews {
       
   public:
     
-    Tensor(const FEValuesBase<spacedim> &fe_values, unsigned int component)
+    Tensor(const FEValues<spacedim> &fe_values, unsigned int component)
       : fe_values_(fe_values),
         first_tensor_component_(component)
     {};
@@ -161,13 +161,13 @@ namespace FEValuesViews {
      */
     arma::vec::fixed<spacedim> divergence(unsigned int function_no, unsigned int point_no) const;
     
-    /// Returns the FEValuesBase class.
-    const FEValuesBase<spacedim> &base() const;
+    /// Returns the FEValues class.
+    const FEValues<spacedim> &base() const;
     
   private:
     
     /// Base FEValues class for access to the FE.
-    const FEValuesBase<spacedim> &fe_values_;
+    const FEValues<spacedim> &fe_values_;
     
     /// Index of the first component of the vector.
     unsigned int first_tensor_component_;

--- a/src/fem/finite_element.hh
+++ b/src/fem/finite_element.hh
@@ -33,7 +33,7 @@
 #include "system/exceptions.hh"                // for ExcAssertMsg::~ExcAsse...
 
 template<unsigned int dim> class FESystem;
-template<unsigned int dim, unsigned int spacedim> class FESideValues;
+template<unsigned int spacedim> class FESideValues;
 template<unsigned int spacedim> class FEValues;
 template<unsigned int spacedim> class FEValuesBase;
 template<unsigned int dim> class FE_P_disc;
@@ -394,7 +394,7 @@ protected:
     friend class FESystem<dim>;
     friend class FEValuesBase<3>;
     friend class FEValues<3>;
-    friend class FESideValues<dim,3>;
+    friend class FESideValues<3>;
     friend class FE_P_disc<dim>;
     friend class SubDOFHandlerMultiDim;
 };

--- a/src/fem/finite_element.hh
+++ b/src/fem/finite_element.hh
@@ -33,9 +33,7 @@
 #include "system/exceptions.hh"                // for ExcAssertMsg::~ExcAsse...
 
 template<unsigned int dim> class FESystem;
-template<unsigned int spacedim> class FESideValues;
 template<unsigned int spacedim> class FEValues;
-template<unsigned int spacedim> class FEValuesBase;
 template<unsigned int dim> class FE_P_disc;
 
 
@@ -392,9 +390,7 @@ protected:
     
     
     friend class FESystem<dim>;
-    friend class FEValuesBase<3>;
     friend class FEValues<3>;
-    friend class FESideValues<3>;
     friend class FE_P_disc<dim>;
     friend class SubDOFHandlerMultiDim;
 };

--- a/src/fem/finite_element.hh
+++ b/src/fem/finite_element.hh
@@ -35,8 +35,7 @@
 template<unsigned int dim> class FESystem;
 template<unsigned int dim, unsigned int spacedim> class FESideValues;
 template<unsigned int dim, unsigned int spacedim> class FEValues;
-template<unsigned int dim, unsigned int spacedim> class FEValuesBase;
-template<unsigned int dim, unsigned int spacedim> class FEValuesData;
+template<unsigned int spacedim> class FEValuesBase;
 template<unsigned int dim> class FE_P_disc;
 
 
@@ -393,7 +392,7 @@ protected:
     
     
     friend class FESystem<dim>;
-    friend class FEValuesBase<dim,3>;
+    friend class FEValuesBase<3>;
     friend class FEValues<dim,3>;
     friend class FESideValues<dim,3>;
     friend class FE_P_disc<dim>;

--- a/src/fem/finite_element.hh
+++ b/src/fem/finite_element.hh
@@ -34,7 +34,7 @@
 
 template<unsigned int dim> class FESystem;
 template<unsigned int dim, unsigned int spacedim> class FESideValues;
-template<unsigned int dim, unsigned int spacedim> class FEValues;
+template<unsigned int spacedim> class FEValues;
 template<unsigned int spacedim> class FEValuesBase;
 template<unsigned int dim> class FE_P_disc;
 
@@ -393,7 +393,7 @@ protected:
     
     friend class FESystem<dim>;
     friend class FEValuesBase<3>;
-    friend class FEValues<dim,3>;
+    friend class FEValues<3>;
     friend class FESideValues<dim,3>;
     friend class FE_P_disc<dim>;
     friend class SubDOFHandlerMultiDim;

--- a/src/fields/fe_value_handler.cc
+++ b/src/fields/fe_value_handler.cc
@@ -134,7 +134,7 @@ void FEValueHandler<elemdim, spacedim, Value>::value_list(const Armor::array  &p
 	FEValues<elemdim,spacedim> fe_values(quad, *dh_->ds()->fe(elm).get<elemdim>(), update_values);
 
     for (unsigned int k=0; k<point_list.size(); k++) {
-		fe_values.reinit( cell );
+		fe_values.reinit( elm );
 
 		Value envelope(value_list[k]);
 		envelope.zeros();

--- a/src/fields/fe_value_handler.cc
+++ b/src/fields/fe_value_handler.cc
@@ -38,7 +38,7 @@ template<int rank, int elemdim, int spacedim, class Value>
 class FEShapeHandler {
 public:
 
-	inline static typename Value::return_type fe_value(FEValues<elemdim,3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
+	inline static typename Value::return_type fe_value(FEValues<spacedim> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
 		ASSERT(false).error("Unsupported format of FieldFE!\n");
 		typename Value::return_type ret;
@@ -53,7 +53,7 @@ public:
 template<int elemdim, int spacedim, class Value>
 class FEShapeHandler<0, elemdim, spacedim, Value> {
 public:
-	inline static typename Value::return_type fe_value(FEValues<elemdim,3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
+	inline static typename Value::return_type fe_value(FEValues<3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
 		return fe_val.scalar_view(comp_index).value(i_dof, i_qp);
 	}
@@ -64,7 +64,7 @@ public:
 template<int elemdim, int spacedim, class Value>
 class FEShapeHandler<1, elemdim, spacedim, Value> {
 public:
-	inline static typename Value::return_type fe_value(FEValues<elemdim,3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
+	inline static typename Value::return_type fe_value(FEValues<3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
 		return fe_val.vector_view(comp_index).value(i_dof, i_qp);
 	}
@@ -75,7 +75,7 @@ public:
 template<int elemdim, int spacedim, class Value>
 class FEShapeHandler<2, elemdim, spacedim, Value> {
 public:
-	inline static typename Value::return_type fe_value(FEValues<elemdim,3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
+	inline static typename Value::return_type fe_value(FEValues<3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
 		return fe_val.tensor_view(comp_index).value(i_dof, i_qp);
 	}
@@ -131,7 +131,8 @@ void FEValueHandler<elemdim, spacedim, Value>::value_list(const Armor::array  &p
 	Quadrature quad(elemdim, point_list.size());
 	for (unsigned int k=0; k<point_list.size(); k++)
         quad.set(k) = RefElement<elemdim>::bary_to_local(MappingP1<elemdim,spacedim>::project_real_to_unit(point_list.vec<spacedim>(k), map_mat));
-	FEValues<elemdim,spacedim> fe_values(quad, *dh_->ds()->fe(elm).get<elemdim>(), update_values);
+	FEValues<spacedim> fe_values;
+	fe_values.initialize(quad, *dh_->ds()->fe(elm).get<elemdim>(), update_values);
 
     for (unsigned int k=0; k<point_list.size(); k++) {
 		fe_values.reinit( elm );

--- a/src/fields/fe_value_handler.cc
+++ b/src/fields/fe_value_handler.cc
@@ -34,7 +34,7 @@
  * Is done by class partial specialization as, we were not able to do this using function overloading (since
  * they differ only by return value) and partial specialization of the function templates is not supported  in C++.
  */
-template<int rank, int elemdim, int spacedim, class Value>
+template<int rank, int spacedim, class Value>
 class FEShapeHandler {
 public:
 
@@ -50,8 +50,8 @@ public:
 
 
 /// Partial template specialization of FEShapeHandler for scalar fields
-template<int elemdim, int spacedim, class Value>
-class FEShapeHandler<0, elemdim, spacedim, Value> {
+template<int spacedim, class Value>
+class FEShapeHandler<0, spacedim, Value> {
 public:
 	inline static typename Value::return_type fe_value(FEValues<3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
@@ -61,8 +61,8 @@ public:
 
 
 /// Partial template specialization of FEShapeHandler for vector fields
-template<int elemdim, int spacedim, class Value>
-class FEShapeHandler<1, elemdim, spacedim, Value> {
+template<int spacedim, class Value>
+class FEShapeHandler<1, spacedim, Value> {
 public:
 	inline static typename Value::return_type fe_value(FEValues<3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
@@ -72,8 +72,8 @@ public:
 
 
 /// Partial template specialization of FEShapeHandler for tensor fields
-template<int elemdim, int spacedim, class Value>
-class FEShapeHandler<2, elemdim, spacedim, Value> {
+template<int spacedim, class Value>
+class FEShapeHandler<2, spacedim, Value> {
 public:
 	inline static typename Value::return_type fe_value(FEValues<3> &fe_val, unsigned int i_dof, unsigned int i_qp, unsigned int comp_index)
 	{
@@ -141,7 +141,7 @@ void FEValueHandler<elemdim, spacedim, Value>::value_list(const Armor::array  &p
 		envelope.zeros();
 		for (unsigned int i=0; i<loc_dofs.n_elem; i++) {
 			value_list[k] += data_vec_[loc_dofs[i]]
-							* FEShapeHandler<Value::rank_, elemdim, spacedim, Value>::fe_value(fe_values, i, k, comp_index_);
+							* FEShapeHandler<Value::rank_, spacedim, Value>::fe_value(fe_values, i, k, comp_index_);
 		}
 	}
 }
@@ -210,12 +210,7 @@ template class FEValueHandler<dim, spacedim, FieldValue<0>::Enum >;             
 template class FEValueHandler<dim, spacedim, FieldValue<0>::Integer >;                \
 template class FEValueHandler<dim, spacedim, FieldValue<0>::Scalar >;                 \
 template class FEValueHandler<dim, spacedim, FieldValue<spacedim>::VectorFixed >;     \
-template class FEValueHandler<dim, spacedim, FieldValue<spacedim>::TensorFixed >;     \
-template class FEShapeHandler<0, dim, spacedim, FieldValue<0>::Enum >;                \
-template class FEShapeHandler<0, dim, spacedim, FieldValue<0>::Integer >;             \
-template class FEShapeHandler<0, dim, spacedim, FieldValue<0>::Scalar >;              \
-template class FEShapeHandler<1, dim, spacedim, FieldValue<spacedim>::VectorFixed >;  \
-template class FEShapeHandler<2, dim, spacedim, FieldValue<spacedim>::TensorFixed >;
+template class FEValueHandler<dim, spacedim, FieldValue<spacedim>::TensorFixed >;
 
 #define INSTANCE_VALUE_HANDLER(dim) \
 INSTANCE_VALUE_HANDLER_ALL(dim,3)
@@ -225,3 +220,9 @@ INSTANCE_VALUE_HANDLER(0);
 INSTANCE_VALUE_HANDLER(1);
 INSTANCE_VALUE_HANDLER(2);
 INSTANCE_VALUE_HANDLER(3);
+
+template class FEShapeHandler<0, 3, FieldValue<0>::Enum >;
+template class FEShapeHandler<0, 3, FieldValue<0>::Integer >;
+template class FEShapeHandler<0, 3, FieldValue<0>::Scalar >;
+template class FEShapeHandler<1, 3, FieldValue<3>::VectorFixed >;
+template class FEShapeHandler<2, 3, FieldValue<3>::TensorFixed >;

--- a/src/flow/assembly_lmh.hh
+++ b/src/flow/assembly_lmh.hh
@@ -384,7 +384,7 @@ protected:
         auto ele = dh_cell.elm();
         
         fe_values_.reinit(ele);
-        unsigned int ndofs = fe_values_.get_fe()->n_dofs();
+        unsigned int ndofs = fe_values_.n_dofs();
         unsigned int qsize = fe_values_.n_points();
         auto velocity = fe_values_.vector_view(0);
 

--- a/src/flow/assembly_lmh.hh
+++ b/src/flow/assembly_lmh.hh
@@ -383,7 +383,7 @@ protected:
         arma::vec3 &gravity_vec = ad_->gravity_vec_;
         auto ele = dh_cell.elm();
         
-        fe_values_.reinit(dh_cell);
+        fe_values_.reinit(ele);
         unsigned int ndofs = fe_values_.get_fe()->n_dofs();
         unsigned int qsize = fe_values_.n_points();
         auto velocity = fe_values_.vector_view(0);
@@ -504,7 +504,7 @@ protected:
             unsigned int p = size()+i; // loc dof of higher ele edge
             
             ElementAccessor<3> ele_higher = neighb_side.cell().elm();
-            ngh_values_.fe_side_values_.reinit(neighb_side);
+            ngh_values_.fe_side_values_.reinit(neighb_side.side());
             nv = ngh_values_.fe_side_values_.normal_vector(0);
 
             double value = ad_->sigma.value( ele.centre(), ele) *

--- a/src/flow/assembly_lmh.hh
+++ b/src/flow/assembly_lmh.hh
@@ -43,14 +43,11 @@ public:
     
     AssemblyLMH<dim>(AssemblyDataPtrLMH data)
     : quad_(dim, 3),
-        fe_values_(quad_, fe_rt_,
-                update_values | update_gradients | update_JxW_values | update_quadrature_points),
-
-        velocity_interpolation_quad_(dim, 0), // veloctiy values in barycenter
-        velocity_interpolation_fv_(velocity_interpolation_quad_, fe_rt_, update_values | update_quadrature_points),
-
-        ad_(data)
+      velocity_interpolation_quad_(dim, 0), // veloctiy values in barycenter
+      ad_(data)
     {
+        fe_values_.initialize(quad_, fe_rt_, update_values | update_gradients | update_JxW_values | update_quadrature_points);
+        velocity_interpolation_fv_.initialize(velocity_interpolation_quad_, fe_rt_, update_values | update_quadrature_points);
         // local numbering of dofs for MH system
         // note: this shortcut supposes that the fe_system is the same on all elements
         // the function DiscreteSpace.fe(ElementAccessor) does not in fact depend on the element accessor
@@ -567,13 +564,13 @@ protected:
     // assembly volume integrals
     FE_RT0<dim> fe_rt_;
     QGauss quad_;
-    FEValues<dim,3> fe_values_;
+    FEValues<3> fe_values_;
 
     NeighSideValues<dim<3?dim:2> ngh_values_;
 
     // Interpolation of velocity into barycenters
     QGauss velocity_interpolation_quad_;
-    FEValues<dim,3> velocity_interpolation_fv_;
+    FEValues<3> velocity_interpolation_fv_;
 
     // data shared by assemblers of different dimension
     AssemblyDataPtrLMH ad_;

--- a/src/flow/assembly_mh.hh
+++ b/src/flow/assembly_mh.hh
@@ -369,7 +369,7 @@ protected:
         const ElementAccessor<3> ele = dh_cell.elm();
         
         fe_values_.reinit(ele);
-        unsigned int ndofs = fe_values_.get_fe()->n_dofs();
+        unsigned int ndofs = fe_values_.n_dofs();
         unsigned int qsize = fe_values_.n_points();
         auto velocity = fe_values_.vector_view(0);
 

--- a/src/flow/assembly_mh.hh
+++ b/src/flow/assembly_mh.hh
@@ -68,10 +68,11 @@ private:
 public:
     NeighSideValues<dim>()
     :  side_quad_(dim, 1),
-       fe_p_disc_(0),
-       fe_side_values_(side_quad_, fe_p_disc_, update_normal_vectors)
-    {}
-    FESideValues<dim+1,3> fe_side_values_;
+       fe_p_disc_(0)
+    {
+        fe_side_values_.initialize(side_quad_, fe_p_disc_, update_normal_vectors);
+    }
+    FESideValues<3> fe_side_values_;
 
 };
 

--- a/src/flow/assembly_mh.hh
+++ b/src/flow/assembly_mh.hh
@@ -88,18 +88,15 @@ public:
     
     AssemblyMH<dim>(AssemblyDataPtrMH data)
     : quad_(dim, 3),
-        fe_values_(quad_, fe_rt_,
-                update_values | update_gradients | update_JxW_values | update_quadrature_points),
-
-        velocity_interpolation_quad_(dim, 0), // veloctiy values in barycenter
-        velocity_interpolation_fv_(velocity_interpolation_quad_, fe_rt_, update_values | update_quadrature_points),
-
-        ad_(data),
-        loc_system_(size(), size()),
-        loc_system_vb_(2,2)
+      velocity_interpolation_quad_(dim, 0), // veloctiy values in barycenter
+      ad_(data),
+      loc_system_(size(), size()),
+      loc_system_vb_(2,2)
 
     {
-
+        fe_values_.initialize(quad_, fe_rt_,
+                update_values | update_gradients | update_JxW_values | update_quadrature_points);
+        velocity_interpolation_fv_.initialize(velocity_interpolation_quad_, fe_rt_, update_values | update_quadrature_points);
 
         // local numbering of dofs for MH system
         unsigned int nsides = dim+1;
@@ -495,13 +492,13 @@ protected:
     // assembly volume integrals
     FE_RT0<dim> fe_rt_;
     QGauss quad_;
-    FEValues<dim,3> fe_values_;
+    FEValues<3> fe_values_;
 
     NeighSideValues< (dim<3) ? dim : 2> ngh_values_;
 
     // Interpolation of velocity into barycenters
     QGauss velocity_interpolation_quad_;
-    FEValues<dim,3> velocity_interpolation_fv_;
+    FEValues<3> velocity_interpolation_fv_;
 
     // data shared by assemblers of different dimension
     AssemblyDataPtrMH ad_;

--- a/src/flow/assembly_mh.hh
+++ b/src/flow/assembly_mh.hh
@@ -72,7 +72,7 @@ public:
     {
         fe_side_values_.initialize(side_quad_, fe_p_disc_, update_normal_vectors);
     }
-    FESideValues<3> fe_side_values_;
+    FEValues<3> fe_side_values_;
 
 };
 

--- a/src/flow/assembly_mh.hh
+++ b/src/flow/assembly_mh.hh
@@ -187,7 +187,7 @@ public:
         // compute normal vector to side
         arma::vec3 nv;
         ElementAccessor<3> ele_higher = ad_->mesh->element_accessor( neighb_side.element().idx() );
-        ngh_values_.fe_side_values_.reinit(neighb_side);
+        ngh_values_.fe_side_values_.reinit(neighb_side.side());
         nv = ngh_values_.fe_side_values_.normal_vector(0);
 
         double value = ad_->sigma.value( ele.centre(), ele) *
@@ -368,7 +368,7 @@ protected:
         arma::vec3 &gravity_vec = ad_->gravity_vec_;
         const ElementAccessor<3> ele = dh_cell.elm();
         
-        fe_values_.reinit(dh_cell);
+        fe_values_.reinit(ele);
         unsigned int ndofs = fe_values_.get_fe()->n_dofs();
         unsigned int qsize = fe_values_.n_points();
         auto velocity = fe_values_.vector_view(0);

--- a/src/flow/darcy_flow_mh_output.cc
+++ b/src/flow/darcy_flow_mh_output.cc
@@ -361,10 +361,12 @@ typedef FieldPython<3, FieldValue<3>::Vector > ExactSolution;
  * 3) difference of divergence
  * */
 
-template <int dim>
 void DarcyFlowMHOutput::l2_diff_local(DHCellAccessor dh_cell,
-                   FEValues<dim,3> &fe_values, FEValues<dim,3> &fv_rt,
+                   FEValues<3> &fe_values, FEValues<3> &fv_rt,
                    ExactSolution &anal_sol,  DarcyFlowMHOutput::DiffData &result) {
+
+    ASSERT_DBG( fe_values.dm() == fv_rt.dm());
+    unsigned int dim = fe_values.dm();
 
     ElementAccessor<3> ele = dh_cell.elm();
     fv_rt.reinit(ele);
@@ -412,7 +414,13 @@ void DarcyFlowMHOutput::l2_diff_local(DHCellAccessor dh_cell,
         // compute postprocesed pressure
         diff = 0;
         for(unsigned int i_shape=0; i_shape < ele->n_sides(); i_shape++) {
-            unsigned int oposite_node = RefElement<dim>::oposite_node(i_shape);
+            unsigned int oposite_node;
+            switch (dim) {
+                case 1: oposite_node =  RefElement<1>::oposite_node(i_shape); break;
+                case 2: oposite_node =  RefElement<2>::oposite_node(i_shape); break;
+                case 3: oposite_node =  RefElement<3>::oposite_node(i_shape); break;
+                default: ASSERT(false)(dim).error("Unsupported FE dimension."); break;
+            }
 
             diff += fluxes[ i_shape ] *
                                (  arma::dot( q_point, q_point )/ 2
@@ -506,13 +514,13 @@ void DarcyFlowMHOutput::compute_l2_difference() {
 
     	switch (dh_cell.dim()) {
         case 1:
-            l2_diff_local<1>( dh_cell, *fe_data.fe_values.get<1>(), *fe_data.fv_rt.get<1>(), anal_sol_1d, diff_data);
+            l2_diff_local( dh_cell, fe_data.fe_values[1], fe_data.fv_rt[1], anal_sol_1d, diff_data);
             break;
         case 2:
-            l2_diff_local<2>( dh_cell, *fe_data.fe_values.get<2>(), *fe_data.fv_rt.get<2>(), anal_sol_2d, diff_data);
+            l2_diff_local( dh_cell, fe_data.fe_values[2], fe_data.fv_rt[2], anal_sol_2d, diff_data);
             break;
         case 3:
-            l2_diff_local<3>( dh_cell, *fe_data.fe_values.get<3>(), *fe_data.fv_rt.get<3>(), anal_sol_3d, diff_data);
+            l2_diff_local( dh_cell, fe_data.fe_values[3], fe_data.fv_rt[3], anal_sol_3d, diff_data);
             break;
         }
     }

--- a/src/flow/darcy_flow_mh_output.cc
+++ b/src/flow/darcy_flow_mh_output.cc
@@ -367,8 +367,8 @@ void DarcyFlowMHOutput::l2_diff_local(DHCellAccessor dh_cell,
                    ExactSolution &anal_sol,  DarcyFlowMHOutput::DiffData &result) {
 
     ElementAccessor<3> ele = dh_cell.elm();
-    fv_rt.reinit(dh_cell);
-    fe_values.reinit(dh_cell);
+    fv_rt.reinit(ele);
+    fe_values.reinit(ele);
     
     double conductivity = result.data_->conductivity.value(ele.centre(), ele );
     double cross = result.data_->cross_section.value(ele.centre(), ele );

--- a/src/flow/darcy_flow_mh_output.cc
+++ b/src/flow/darcy_flow_mh_output.cc
@@ -365,8 +365,8 @@ void DarcyFlowMHOutput::l2_diff_local(DHCellAccessor dh_cell,
                    FEValues<3> &fe_values, FEValues<3> &fv_rt,
                    ExactSolution &anal_sol,  DarcyFlowMHOutput::DiffData &result) {
 
-    ASSERT_DBG( fe_values.dm() == fv_rt.dm());
-    unsigned int dim = fe_values.dm();
+    ASSERT_DBG( fe_values.dim() == fv_rt.dim());
+    unsigned int dim = fe_values.dim();
 
     ElementAccessor<3> ele = dh_cell.elm();
     fv_rt.reinit(ele);

--- a/src/flow/darcy_flow_mh_output.hh
+++ b/src/flow/darcy_flow_mh_output.hh
@@ -53,7 +53,7 @@ namespace Input {
 	}
 }
 
-template<unsigned int dim, unsigned int spacedim> class FEValues;
+template<unsigned int spacedim> class FEValues;
 template <int spacedim, class Value> class FieldFE;
 
 /**
@@ -191,19 +191,18 @@ protected:
         // following is used for calculation of postprocessed pressure difference
         // and comparison to analytical solution
         MixedPtr<FE_P_disc> fe_p0;
-        MixedPtr<FEValues> fe_values;
+        std::vector<FEValues<3>> fe_values;
         
         // FEValues for velocity.
         MixedPtr<FE_RT0> fe_rt;
-        MixedPtr<FEValues> fv_rt;
+        std::vector<FEValues<3>> fv_rt;
     };
     
     FEData fe_data;
     
     /// Computes L2 error on an element.
-    template <int dim>
     void l2_diff_local(DHCellAccessor dh_cell,
-                      FEValues<dim,3> &fe_values, FEValues<dim,3> &fv_rt,
+                      FEValues<3> &fe_values, FEValues<3> &fv_rt,
                       FieldPython<3, FieldValue<3>::Vector > &anal_sol,  DiffData &result);
 };
 

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -656,7 +656,7 @@ void Elasticity::assemble_fluxes_element_side()
     fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
  
-    vector<FEValuesSpaceBase<3>*> fv_sb(2);
+    vector<FEValuesBase<3>*> fv_sb(2);
     const unsigned int ndofs_side = feo->fe<dim>()->n_dofs();    // number of local dofs
     const unsigned int ndofs_sub  = feo->fe<dim-1>()->n_dofs();
     const unsigned int qsize = feo->q<dim-1>()->size();     // number of quadrature points

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -485,7 +485,8 @@ double lame_lambda(double young, double poisson)
 template<unsigned int dim>
 void Elasticity::assemble_volume_integrals()
 {
-    FEValues<dim,3> fe_values(*feo->q<dim>(), *feo->fe<dim>(),
+    FEValues<3> fe_values;
+    fe_values.initialize(*feo->q<dim>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim>()->size();
     vector<int> dof_indices(ndofs);
@@ -546,7 +547,8 @@ void Elasticity::set_sources()
 template<unsigned int dim>
 void Elasticity::set_sources()
 {
-    FEValues<dim,3> fe_values(*feo->q<dim>(), *feo->fe<dim>(),
+    FEValues<3> fe_values;
+    fe_values.initialize(*feo->q<dim>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim>()->size();
     vector<arma::vec3> load(qsize);
@@ -646,7 +648,8 @@ template<unsigned int dim>
 void Elasticity::assemble_fluxes_element_side()
 {
 	if (dim == 1) return;
-    FEValues<dim-1,3> fe_values_sub(*feo->q<dim-1>(), *feo->fe<dim-1>(),
+    FEValues<3> fe_values_sub;
+    fe_values_sub.initialize(*feo->q<dim-1>(), *feo->fe<dim-1>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
     FESideValues<dim,3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -500,7 +500,7 @@ void Elasticity::assemble_volume_integrals()
         if (cell.dim() != dim) continue;
         ElementAccessor<3> elm_acc = cell.elm();
 
-        fe_values.reinit(cell);
+        fe_values.reinit(elm_acc);
         cell.get_dof_indices(dof_indices);
 
         data_.cross_section.value_list(fe_values.point_list(), elm_acc, csection);
@@ -562,7 +562,7 @@ void Elasticity::set_sources()
         if (cell.dim() != dim) continue;
         ElementAccessor<3> elm_acc = cell.elm();
 
-        fe_values.reinit(cell);
+        fe_values.reinit(elm_acc);
         cell.get_dof_indices(dof_indices);
 
         // assemble the local stiffness matrix
@@ -623,7 +623,7 @@ void Elasticity::assemble_fluxes_boundary()
         DHCellAccessor dh_cell = feo->dh()->cell_accessor_from_element(cell.idx());
         DHCellSide dh_side(dh_cell, side->side_idx());
         dh_cell.get_dof_indices(side_dof_indices);
-        fe_values_side.reinit(dh_side);
+        fe_values_side.reinit(*side);
 //         unsigned int bc_type = data_.bc_type.value(side->centre(), side->cond()->element_accessor());
  
 //         for (unsigned int i=0; i<ndofs; i++)
@@ -681,13 +681,13 @@ void Elasticity::assemble_fluxes_element_side()
 		ElementAccessor<3> cell_sub = nb->element();
         DHCellAccessor dh_cell_sub = feo->dh()->cell_accessor_from_element(cell_sub.idx());
         dh_cell_sub.get_dof_indices(side_dof_indices[0]);
-		fe_values_sub.reinit(dh_cell_sub);
+		fe_values_sub.reinit(cell_sub);
 
 		ElementAccessor<3> cell = nb->side()->element();
 		DHCellAccessor dh_cell = feo->dh()->cell_accessor_from_element(cell.idx());
         DHCellSide dh_side(dh_cell, nb->side()->side_idx());
         dh_cell.get_dof_indices(side_dof_indices[1]);
-		fe_values_side.reinit(dh_side);
+		fe_values_side.reinit(dh_side.side());
 
 		// Element id's for testing if they belong to local partition.
 		bool own_element_id[2];
@@ -821,7 +821,7 @@ void Elasticity::set_boundary_conditions()
 
  			unsigned int bc_type = data_.bc_type.value(side->centre(), bc_cell);
 
-			fe_values_side.reinit(dh_side);
+			fe_values_side.reinit(*side);
 
 			data_.cross_section.value_list(fe_values_side.point_list(), elm, csection);
 			// The b.c. data are fetched for all possible b.c. types since we allow

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -604,7 +604,8 @@ void Elasticity::set_sources()
 template<unsigned int dim>
 void Elasticity::assemble_fluxes_boundary()
 {
-    FESideValues<dim,3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
+    FESideValues<3> fe_values_side;
+    fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs();
     vector<int> side_dof_indices(ndofs);
@@ -651,7 +652,8 @@ void Elasticity::assemble_fluxes_element_side()
     FEValues<3> fe_values_sub;
     fe_values_sub.initialize(*feo->q<dim-1>(), *feo->fe<dim-1>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
-    FESideValues<dim,3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
+    FESideValues<3> fe_values_side;
+    fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
  
     vector<FEValuesSpaceBase<3>*> fv_sb(2);
@@ -786,7 +788,8 @@ void Elasticity::set_boundary_conditions()
 template<unsigned int dim>
 void Elasticity::set_boundary_conditions()
 {
-    FESideValues<dim,3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
+    FESideValues<3> fe_values_side;
+    fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_normal_vectors | update_side_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim-1>()->size();
     vector<int> side_dof_indices(ndofs);

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -485,8 +485,7 @@ double lame_lambda(double young, double poisson)
 template<unsigned int dim>
 void Elasticity::assemble_volume_integrals()
 {
-    FEValues<3> fe_values;
-    fe_values.initialize(*feo->q<dim>(), *feo->fe<dim>(),
+    FEValues<3> fe_values(*feo->q<dim>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim>()->size();
     vector<int> dof_indices(ndofs);
@@ -547,8 +546,7 @@ void Elasticity::set_sources()
 template<unsigned int dim>
 void Elasticity::set_sources()
 {
-    FEValues<3> fe_values;
-    fe_values.initialize(*feo->q<dim>(), *feo->fe<dim>(),
+    FEValues<3> fe_values(*feo->q<dim>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim>()->size();
     vector<arma::vec3> load(qsize);
@@ -604,8 +602,7 @@ void Elasticity::set_sources()
 template<unsigned int dim>
 void Elasticity::assemble_fluxes_boundary()
 {
-    FEValues<3> fe_values_side;
-    fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
+    FEValues<3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs();
     vector<int> side_dof_indices(ndofs);
@@ -649,11 +646,9 @@ template<unsigned int dim>
 void Elasticity::assemble_fluxes_element_side()
 {
 	if (dim == 1) return;
-    FEValues<3> fe_values_sub;
-    fe_values_sub.initialize(*feo->q<dim-1>(), *feo->fe<dim-1>(),
+    FEValues<3> fe_values_sub(*feo->q<dim-1>(), *feo->fe<dim-1>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
-    FEValues<3> fe_values_side;
-    fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
+    FEValues<3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
  
     const unsigned int ndofs_side = feo->fe<dim>()->n_dofs();    // number of local dofs
@@ -785,8 +780,7 @@ void Elasticity::set_boundary_conditions()
 template<unsigned int dim>
 void Elasticity::set_boundary_conditions()
 {
-    FEValues<3> fe_values_side;
-    fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
+    FEValues<3> fe_values_side(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_normal_vectors | update_side_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim-1>()->size();
     vector<int> side_dof_indices(ndofs);

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -656,7 +656,6 @@ void Elasticity::assemble_fluxes_element_side()
     fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
  
-    vector<FEValues<3>*> fv_sb(2);
     const unsigned int ndofs_side = feo->fe<dim>()->n_dofs();    // number of local dofs
     const unsigned int ndofs_sub  = feo->fe<dim-1>()->n_dofs();
     const unsigned int qsize = feo->q<dim-1>()->size();     // number of quadrature points
@@ -673,8 +672,6 @@ void Elasticity::assemble_fluxes_element_side()
     // index 1 = side of element with higher dimension
     side_dof_indices[0].resize(ndofs_sub);
     side_dof_indices[1].resize(ndofs_side);
-    fv_sb[0] = &fe_values_sub;
-    fv_sb[1] = &fe_values_side;
 
     // assemble integral over sides
     for (unsigned int inb=0; inb<feo->dh()->n_loc_nb(); inb++)
@@ -750,7 +747,7 @@ void Elasticity::assemble_fluxes_element_side()
                                       + lambda*divuit*nv
                                      )
                                      - arma::dot(gvft, mu*arma::kron(nv,ui.t()) + lambda*arma::dot(ui,nv)*arma::eye(3,3))
-                                    )*fv_sb[0]->JxW(k);
+                                    )*fe_values_sub.JxW(k);
                         }
                 }
             }

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -604,7 +604,7 @@ void Elasticity::set_sources()
 template<unsigned int dim>
 void Elasticity::assemble_fluxes_boundary()
 {
-    FESideValues<3> fe_values_side;
+    FEValues<3> fe_values_side;
     fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs();
@@ -652,11 +652,11 @@ void Elasticity::assemble_fluxes_element_side()
     FEValues<3> fe_values_sub;
     fe_values_sub.initialize(*feo->q<dim-1>(), *feo->fe<dim-1>(),
     		update_values | update_gradients | update_JxW_values | update_quadrature_points);
-    FESideValues<3> fe_values_side;
+    FEValues<3> fe_values_side;
     fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
  
-    vector<FEValuesBase<3>*> fv_sb(2);
+    vector<FEValues<3>*> fv_sb(2);
     const unsigned int ndofs_side = feo->fe<dim>()->n_dofs();    // number of local dofs
     const unsigned int ndofs_sub  = feo->fe<dim-1>()->n_dofs();
     const unsigned int qsize = feo->q<dim-1>()->size();     // number of quadrature points
@@ -788,7 +788,7 @@ void Elasticity::set_boundary_conditions()
 template<unsigned int dim>
 void Elasticity::set_boundary_conditions()
 {
-    FESideValues<3> fe_values_side;
+    FEValues<3> fe_values_side;
     fe_values_side.initialize(*feo->q<dim-1>(), *feo->fe<dim>(),
     		update_values | update_gradients | update_normal_vectors | update_side_JxW_values | update_quadrature_points);
     const unsigned int ndofs = feo->fe<dim>()->n_dofs(), qsize = feo->q<dim-1>()->size();

--- a/src/mechanics/elasticity.hh
+++ b/src/mechanics/elasticity.hh
@@ -33,7 +33,6 @@
 class Distribution;
 class OutputTime;
 class DOFHandlerMultiDim;
-template<unsigned int dim, unsigned int spacedim> class FEValuesBase;
 template<unsigned int dim> class FiniteElement;
 class Elasticity;
 

--- a/src/mesh/accessors.hh
+++ b/src/mesh/accessors.hh
@@ -201,8 +201,12 @@ public:
      */
     double quality_measure_smooth(SideIter side) const;
 
-    bool operator==(const ElementAccessor<spacedim>& other) {
+    inline bool operator==(const ElementAccessor<spacedim>& other) const {
     	return (element_idx_ == other.element_idx_);
+    }
+
+    inline bool operator!=(const ElementAccessor<spacedim>& other) const {
+    	return (element_idx_ != other.element_idx_);
     }
 
     /**

--- a/src/mesh/sides.h
+++ b/src/mesh/sides.h
@@ -109,6 +109,15 @@ public:
      */
     inline void inc();
 
+    inline bool operator==(const Side &other) const {
+        return (mesh_ == other.mesh_ ) && ( elem_idx_ == other.elem_idx_ )
+        		&& ( side_idx_ == other.side_idx_ );
+    }
+
+    inline bool operator!=(const Side &other) const {
+        return !( *this == other);
+    }
+
     /// This is necessary by current DofHandler, should change this
     //inline void *make_ptr() const;
 private:
@@ -138,14 +147,13 @@ public:
     : side_(side)
     {}
 
-    inline bool operator==(const SideIter &other) {
-        return (side_.mesh() == other.side_.mesh() ) && ( side_.elem_idx() == other.side_.elem_idx() )
-        		&& ( side_.side_idx() == other.side_.side_idx() );
+    inline bool operator==(const SideIter &other) const {
+        return side_ == other.side_;
     }
 
 
-    inline bool operator!=(const SideIter &other) {
-        return !( *this == other);
+    inline bool operator!=(const SideIter &other) const {
+        return side_ != other.side_;
     }
 
     ///  * dereference operator

--- a/src/system/armor.hh
+++ b/src/system/armor.hh
@@ -618,6 +618,7 @@ public:
             ASSERT_EQ(n_rows_, nr);
             ASSERT_EQ(n_cols_, nc);
             copy<nr, nc>(arma_x.memptr());
+            return *this;
         }
 
         template<long long unsigned int nr>
@@ -646,11 +647,11 @@ public:
      * @param nc    Number of columns in each matrix.
      */
     Array(uint nr, uint nc = 1, uint size = 0)
-    : n_rows_(nr),
+    : data_(new Type[nr * nc * size]),
+      n_rows_(nr),
       n_cols_(nc),
       size_(size),
-      reserved_(size),
-      data_(new Type[nr * nc * size])
+      reserved_(size)
     {
     }
     

--- a/src/system/logger.hh
+++ b/src/system/logger.hh
@@ -231,6 +231,7 @@ Logger &operator<<(Logger & log, const std::vector<T> & vec)
 {
     for (T const& c : vec)
         log << c << " ";
+	return log;
 }
 
 

--- a/src/transport/assembly_dg.hh
+++ b/src/transport/assembly_dg.hh
@@ -70,12 +70,12 @@ public:
       fe_rt_(new FE_RT0<dim>), fe_rt_low_(new FE_RT0<dim-1>),
       quad_(new QGauss(dim, 2*data->dg_order)),
 	  quad_low_(new QGauss(dim-1, 2*data->dg_order)),
-      model_(model), data_(data),
-      fe_values_side_(*quad_low_, *fe_, update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points),
-      fsv_rt_(*quad_low_, *fe_rt_, update_values | update_quadrature_points) {
+      model_(model), data_(data){
 
         fv_rt_.initialize(*quad_, *fe_rt_, update_values | update_gradients | update_quadrature_points);
         fe_values_.initialize(*quad_, *fe_, update_values | update_gradients | update_JxW_values | update_quadrature_points);
+        fe_values_side_.initialize(*quad_low_, *fe_, update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
+        fsv_rt_.initialize(*quad_low_, *fe_rt_, update_values | update_quadrature_points);
 
         if (dim>1) {
             fv_rt_vb_.initialize(*quad_low_, *fe_rt_low_, update_values | update_quadrature_points);
@@ -96,11 +96,6 @@ public:
         delete fe_rt_low_;
         delete quad_;
         delete quad_low_;
-
-        for (unsigned int i=0; i<data_->ad_coef_edg.size(); i++)
-        {
-            delete fe_values_vec_[i];
-        }
     }
 
     /// Initialize auxiliary vectors and other data members
@@ -133,11 +128,12 @@ public:
             ret_coef_[sbi].resize(qsize_);
         }
 
+        fe_values_vec_.resize(data_->ad_coef_edg.size());
         for (unsigned int sid=0; sid<data_->ad_coef_edg.size(); sid++)
         {
             side_dof_indices_.push_back( vector<LongIdx>(ndofs_) );
-            fe_values_vec_.push_back(new FESideValues<dim,3>(*quad_low_, *fe_,
-                    update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points));
+            fe_values_vec_[sid].initialize(*quad_low_, *fe_,
+                    update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
         }
 
         // index 0 = element with lower dimension,
@@ -334,16 +330,16 @@ public:
                 auto dh_edge_cell = data_->dh_->cell_accessor_from_element( edge_side.elem_idx() );
                 ElementAccessor<3> edg_elm = dh_edge_cell.elm();
                 dh_edge_cell.get_dof_indices(side_dof_indices_[sid]);
-                fe_values_vec_[sid]->reinit(edge_side.side());
+                fe_values_vec_[sid].reinit(edge_side.side());
                 fsv_rt_.reinit(edge_side.side());
                 calculate_velocity(edg_elm, side_velocity_vec_[sid], fsv_rt_.point_list());
-                model_.compute_advection_diffusion_coefficients(fe_values_vec_[sid]->point_list(), side_velocity_vec_[sid], edg_elm, data_->ad_coef_edg[sid], data_->dif_coef_edg[sid]);
+                model_.compute_advection_diffusion_coefficients(fe_values_vec_[sid].point_list(), side_velocity_vec_[sid], edg_elm, data_->ad_coef_edg[sid], data_->dif_coef_edg[sid]);
                 dg_penalty_[sid].resize(model_.n_substances());
                 for (unsigned int sbi=0; sbi<model_.n_substances(); sbi++)
                     dg_penalty_[sid][sbi] = data_->dg_penalty[sbi].value(edg_elm.centre(), edg_elm);
                 ++sid;
             }
-            arma::vec3 normal_vector = fe_values_vec_[0]->normal_vector(0);
+            arma::vec3 normal_vector = fe_values_vec_[0].normal_vector(0);
 
             // fluxes and penalty
             for (unsigned int sbi=0; sbi<model_.n_substances(); sbi++)
@@ -355,7 +351,7 @@ public:
                 {
                     fluxes[sid] = 0;
                     for (unsigned int k=0; k<qsize_lower_dim_; k++)
-                        fluxes[sid] += arma::dot(data_->ad_coef_edg[sid][sbi][k], fe_values_vec_[sid]->normal_vector(k))*fe_values_vec_[sid]->JxW(k);
+                        fluxes[sid] += arma::dot(data_->ad_coef_edg[sid][sbi][k], fe_values_vec_[sid].normal_vector(k))*fe_values_vec_[sid].JxW(k);
                     fluxes[sid] /= edge_side.measure();
                     if (fluxes[sid] > 0)
                         pflux += fluxes[sid];
@@ -374,7 +370,7 @@ public:
                         if (s2<=s1) continue;
                         ASSERT(edge_side1.is_valid()).error("Invalid side of edge.");
 
-                        arma::vec3 nv = fe_values_vec_[s1]->normal_vector(0);
+                        arma::vec3 nv = fe_values_vec_[s1].normal_vector(0);
 
                         // set up the parameters for DG method
                         // calculate the flux from edge_side1 to edge_side2
@@ -418,9 +414,9 @@ public:
                         sd[0] = s1; is_side_own[0] = edge_side1.cell().is_own();
                         sd[1] = s2; is_side_own[1] = edge_side2.cell().is_own();
 
-#define AVERAGE(i,k,side_id)  (fe_values_vec_[sd[side_id]]->shape_value(i,k)*0.5)
-#define WAVERAGE(i,k,side_id) (arma::dot(data_->dif_coef_edg[sd[side_id]][sbi][k]*fe_values_vec_[sd[side_id]]->shape_grad(i,k),nv)*omega[side_id])
-#define JUMP(i,k,side_id)     ((side_id==0?1:-1)*fe_values_vec_[sd[side_id]]->shape_value(i,k))
+#define AVERAGE(i,k,side_id)  (fe_values_vec_[sd[side_id]].shape_value(i,k)*0.5)
+#define WAVERAGE(i,k,side_id) (arma::dot(data_->dif_coef_edg[sd[side_id]][sbi][k]*fe_values_vec_[sd[side_id]].shape_grad(i,k),nv)*omega[side_id])
+#define JUMP(i,k,side_id)     ((side_id==0?1:-1)*fe_values_vec_[sd[side_id]].shape_value(i,k))
 
                         // For selected pair of elements:
                         for (int n=0; n<2; n++)
@@ -429,25 +425,25 @@ public:
 
                             for (int m=0; m<2; m++)
                             {
-                                for (unsigned int i=0; i<fe_values_vec_[sd[n]]->n_dofs(); i++)
-                                    for (unsigned int j=0; j<fe_values_vec_[sd[m]]->n_dofs(); j++)
-                                        local_matrix_[i*fe_values_vec_[sd[m]]->n_dofs()+j] = 0;
+                                for (unsigned int i=0; i<fe_values_vec_[sd[n]].n_dofs(); i++)
+                                    for (unsigned int j=0; j<fe_values_vec_[sd[m]].n_dofs(); j++)
+                                        local_matrix_[i*fe_values_vec_[sd[m]].n_dofs()+j] = 0;
 
                                 for (unsigned int k=0; k<qsize_lower_dim_; k++)
                                 {
-                                    double flux_times_JxW = transport_flux*fe_values_vec_[0]->JxW(k);
-                                    double gamma_times_JxW = gamma_l*fe_values_vec_[0]->JxW(k);
+                                    double flux_times_JxW = transport_flux*fe_values_vec_[0].JxW(k);
+                                    double gamma_times_JxW = gamma_l*fe_values_vec_[0].JxW(k);
 
-                                    for (unsigned int i=0; i<fe_values_vec_[sd[n]]->n_dofs(); i++)
+                                    for (unsigned int i=0; i<fe_values_vec_[sd[n]].n_dofs(); i++)
                                     {
                                         double flux_JxW_jump_i = flux_times_JxW*JUMP(i,k,n);
                                         double gamma_JxW_jump_i = gamma_times_JxW*JUMP(i,k,n);
-                                        double JxW_jump_i = fe_values_vec_[0]->JxW(k)*JUMP(i,k,n);
-                                        double JxW_var_wavg_i = fe_values_vec_[0]->JxW(k)*WAVERAGE(i,k,n)*data_->dg_variant;
+                                        double JxW_jump_i = fe_values_vec_[0].JxW(k)*JUMP(i,k,n);
+                                        double JxW_var_wavg_i = fe_values_vec_[0].JxW(k)*WAVERAGE(i,k,n)*data_->dg_variant;
 
-                                        for (unsigned int j=0; j<fe_values_vec_[sd[m]]->n_dofs(); j++)
+                                        for (unsigned int j=0; j<fe_values_vec_[sd[m]].n_dofs(); j++)
                                         {
-                                            int index = i*fe_values_vec_[sd[m]]->n_dofs()+j;
+                                            int index = i*fe_values_vec_[sd[m]].n_dofs()+j;
 
                                             // flux due to transport (applied on interior edges) (average times jump)
                                             local_matrix_[index] += flux_JxW_jump_i*AVERAGE(j,k,m);
@@ -461,7 +457,7 @@ public:
                                         }
                                     }
                                 }
-                                data_->ls[sbi]->mat_set_values(fe_values_vec_[sd[n]]->n_dofs(), &(side_dof_indices_[sd[n]][0]), fe_values_vec_[sd[m]]->n_dofs(), &(side_dof_indices_[sd[m]][0]), &(local_matrix_[0]));
+                                data_->ls[sbi]->mat_set_values(fe_values_vec_[sd[n]].n_dofs(), &(side_dof_indices_[sd[n]][0]), fe_values_vec_[sd[m]].n_dofs(), &(side_dof_indices_[sd[m]][0]), &(local_matrix_[0]));
                             }
                         }
 #undef AVERAGE
@@ -815,9 +811,9 @@ private:
     FEValues<3> fe_values_;                                   ///< FEValues of object (of P disc finite element type)
     FEValues<3> fv_rt_vb_;                                    ///< FEValues of dim-1 object (of RT0 finite element type)
     FEValues<3> fe_values_vb_;                                ///< FEValues of dim-1 object (of P disc finite element type)
-    FESideValues<dim,3> fe_values_side_;                      ///< FESideValues of object (of P disc finite element type)
-    FESideValues<dim,3> fsv_rt_;                              ///< FESideValues of object (of RT0 finite element type)
-    vector<FESideValues<dim,3>*> fe_values_vec_;              ///< Vector of FESideValues of object (of P disc finite element types)
+    FESideValues<3> fe_values_side_;                      ///< FESideValues of object (of P disc finite element type)
+    FESideValues<3> fsv_rt_;                              ///< FESideValues of object (of RT0 finite element type)
+    vector<FESideValues<3>> fe_values_vec_;              ///< Vector of FESideValues of object (of P disc finite element types)
     vector<FEValuesSpaceBase<3>*> fv_sb_;                     ///< Auxiliary vector, holds FEValues objects for assemble element-side
 
     vector<LongIdx> dof_indices_;                             ///< Vector of global DOF indices

--- a/src/transport/assembly_dg.hh
+++ b/src/transport/assembly_dg.hh
@@ -154,7 +154,7 @@ public:
         ASSERT_EQ_DBG(cell.dim(), dim).error("Dimension of element mismatch!");
         ElementAccessor<3> elm = cell.elm();
 
-        fe_values_.reinit(cell);
+        fe_values_.reinit(elm);
         cell.get_dof_indices(dof_indices_);
 
         model_.compute_mass_matrix_coefficient(fe_values_.point_list(), elm, mm_coef_);
@@ -198,8 +198,8 @@ public:
 
         ElementAccessor<3> elm = cell.elm();
 
-        fe_values_.reinit(cell);
-        fv_rt_.reinit(cell);
+        fe_values_.reinit(elm);
+        fv_rt_.reinit(elm);
         cell.get_dof_indices(dof_indices_);
 
         calculate_velocity(elm, velocity_, fv_rt_.point_list());
@@ -247,8 +247,8 @@ public:
 
             ElementAccessor<3> elm_acc = cell.elm();
             cell.get_dof_indices(dof_indices_);
-            fe_values_side_.reinit(cell_side);
-            fsv_rt_.reinit(cell_side);
+            fe_values_side_.reinit(side);
+            fsv_rt_.reinit(side);
 
             calculate_velocity(elm_acc, velocity_, fsv_rt_.point_list());
             model_.compute_advection_diffusion_coefficients(fe_values_side_.point_list(), velocity_, elm_acc, data_->ad_coef, data_->dif_coef);
@@ -335,8 +335,8 @@ public:
                 auto dh_edge_cell = data_->dh_->cell_accessor_from_element( edge_side.elem_idx() );
                 ElementAccessor<3> edg_elm = dh_edge_cell.elm();
                 dh_edge_cell.get_dof_indices(side_dof_indices_[sid]);
-                fe_values_vec_[sid]->reinit(edge_side);
-                fsv_rt_.reinit(edge_side);
+                fe_values_vec_[sid]->reinit(edge_side.side());
+                fsv_rt_.reinit(edge_side.side());
                 calculate_velocity(edg_elm, side_velocity_vec_[sid], fsv_rt_.point_list());
                 model_.compute_advection_diffusion_coefficients(fe_values_vec_[sid]->point_list(), side_velocity_vec_[sid], edg_elm, data_->ad_coef_edg[sid], data_->dif_coef_edg[sid]);
                 dg_penalty_[sid].resize(model_.n_substances());
@@ -495,7 +495,7 @@ public:
             for(unsigned int i=0; i<n_indices; ++i) {
                 side_dof_indices_vb_[i] = dof_indices_[i];
             }
-            fe_values_vb_->reinit(cell_lower_dim);
+            fe_values_vb_->reinit(elm_lower_dim);
             n_dofs[0] = fv_sb_[0]->n_dofs();
 
             DHCellAccessor cell_higher_dim = data_->dh_->cell_accessor_from_element( neighb_side.element().idx() );
@@ -504,7 +504,7 @@ public:
             for(unsigned int i=0; i<n_indices; ++i) {
                 side_dof_indices_vb_[i+n_dofs[0]] = dof_indices_[i];
             }
-            fe_values_side_.reinit(neighb_side);
+            fe_values_side_.reinit(neighb_side.side());
             n_dofs[1] = fv_sb_[1]->n_dofs();
 
             // Testing element if they belong to local partition.
@@ -512,8 +512,8 @@ public:
             own_element_id[0] = cell_lower_dim.is_own();
             own_element_id[1] = cell_higher_dim.is_own();
 
-            fsv_rt_.reinit(neighb_side);
-            fv_rt_vb_->reinit(cell_lower_dim);
+            fsv_rt_.reinit(neighb_side.side());
+            fv_rt_vb_->reinit(elm_lower_dim);
             calculate_velocity(elm_higher_dim, velocity_higher_, fsv_rt_.point_list());
             calculate_velocity(elm_lower_dim, velocity_, fv_rt_vb_->point_list());
             model_.compute_advection_diffusion_coefficients(fe_values_vb_->point_list(), velocity_, elm_lower_dim, data_->ad_coef_edg[0], data_->dif_coef_edg[0]);
@@ -575,7 +575,7 @@ public:
 
         ElementAccessor<3> elm = cell.elm();
 
-        fe_values_.reinit(cell);
+        fe_values_.reinit(elm);
         cell.get_dof_indices(dof_indices_);
 
         model_.compute_source_coefficients(fe_values_.point_list(), elm, sources_conc_, sources_density_, sources_sigma_);
@@ -631,9 +631,8 @@ public:
             arma::uvec bc_type;
             model_.get_bc_type(ele_acc, bc_type);
 
-            DHCellSide dh_side(cell, side.side_idx());
-            fe_values_side_.reinit(dh_side);
-            fsv_rt_.reinit(dh_side);
+            fe_values_side_.reinit(side);
+            fsv_rt_.reinit(side);
             calculate_velocity(elm, velocity_, fsv_rt_.point_list());
 
             model_.compute_advection_diffusion_coefficients(fe_values_side_.point_list(), velocity_, side.element(), data_->ad_coef, data_->dif_coef);
@@ -752,7 +751,7 @@ public:
 
         ElementAccessor<3> elem = cell.elm();
         cell.get_dof_indices(dof_indices_);
-        fe_values_.reinit(cell);
+        fe_values_.reinit(elem);
         model_.compute_init_cond(fe_values_.point_list(), elem, init_values_);
 
         for (unsigned int sbi=0; sbi<model_.n_substances(); sbi++)

--- a/src/transport/assembly_dg.hh
+++ b/src/transport/assembly_dg.hh
@@ -814,7 +814,7 @@ private:
     FESideValues<3> fe_values_side_;                      ///< FESideValues of object (of P disc finite element type)
     FESideValues<3> fsv_rt_;                              ///< FESideValues of object (of RT0 finite element type)
     vector<FESideValues<3>> fe_values_vec_;              ///< Vector of FESideValues of object (of P disc finite element types)
-    vector<FEValuesSpaceBase<3>*> fv_sb_;                     ///< Auxiliary vector, holds FEValues objects for assemble element-side
+    vector<FEValuesBase<3>*> fv_sb_;                     ///< Auxiliary vector, holds FEValues objects for assemble element-side
 
     vector<LongIdx> dof_indices_;                             ///< Vector of global DOF indices
     vector<LongIdx> loc_dof_indices_;                         ///< Vector of local DOF indices

--- a/src/transport/assembly_dg.hh
+++ b/src/transport/assembly_dg.hh
@@ -811,10 +811,10 @@ private:
     FEValues<3> fe_values_;                                   ///< FEValues of object (of P disc finite element type)
     FEValues<3> fv_rt_vb_;                                    ///< FEValues of dim-1 object (of RT0 finite element type)
     FEValues<3> fe_values_vb_;                                ///< FEValues of dim-1 object (of P disc finite element type)
-    FESideValues<3> fe_values_side_;                      ///< FESideValues of object (of P disc finite element type)
-    FESideValues<3> fsv_rt_;                              ///< FESideValues of object (of RT0 finite element type)
-    vector<FESideValues<3>> fe_values_vec_;              ///< Vector of FESideValues of object (of P disc finite element types)
-    vector<FEValuesBase<3>*> fv_sb_;                     ///< Auxiliary vector, holds FEValues objects for assemble element-side
+    FEValues<3> fe_values_side_;                      ///< FEValues of object (of P disc finite element type)
+    FEValues<3> fsv_rt_;                              ///< FEValues of object (of RT0 finite element type)
+    vector<FEValues<3>> fe_values_vec_;              ///< Vector of FEValues of object (of P disc finite element types)
+    vector<FEValues<3>*> fv_sb_;                     ///< Auxiliary vector, holds FEValues objects for assemble element-side
 
     vector<LongIdx> dof_indices_;                             ///< Vector of global DOF indices
     vector<LongIdx> loc_dof_indices_;                         ///< Vector of local DOF indices

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -321,7 +321,7 @@ void ConvectionTransport::set_initial_condition()
 //=============================================================================
 void ConvectionTransport::alloc_transport_vectors() {
 
-    unsigned int i, sbi, n_subst;
+    unsigned int sbi, n_subst;
     n_subst = n_substances();
     
     sources_corr = new double*[n_subst];
@@ -780,7 +780,6 @@ void ConvectionTransport::create_transport_matrix_mpi() {
 
     ElementAccessor<3> el2;
     ElementAccessor<3> elm;
-    const Edge *edg;
     int j;
     LongIdx new_j, new_i;
     double aij, aii;
@@ -908,7 +907,7 @@ double ConvectionTransport::calculate_side_flux(const DHCellSide &cell_side)
 {
     ASSERT_EQ(cell_side.dim(), dim).error("Element dimension mismatch!");
 
-    feo_.fe_values<dim>()->reinit(cell_side);
+    feo_.fe_values<dim>()->reinit(cell_side.side());
     auto vel = velocity_field_ptr_->value(cell_side.centre(), cell_side.element());
     double side_flux = arma::dot(vel, feo_.fe_values<dim>()->normal_vector(0)) * feo_.fe_values<dim>()->JxW(0);
     return side_flux;

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -127,11 +127,11 @@ FETransportObjects::FETransportObjects()
     fe3_ = new FE_P_disc<3>(0);
 
 
-    fe_values1_.initialize(q(0), *fe1_,
+    fe_values_[0].initialize(q(0), *fe1_,
             update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
-    fe_values2_.initialize(q(1), *fe2_,
+    fe_values_[1].initialize(q(1), *fe2_,
             update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
-    fe_values3_.initialize(q(2), *fe3_,
+    fe_values_[2].initialize(q(2), *fe3_,
             update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
 }
 
@@ -151,9 +151,6 @@ template<> FiniteElement<3> *FETransportObjects::fe<3>() { return fe3_; }
 
 Quadrature &FETransportObjects::q(unsigned int dim) { return q_[dim]; }
 
-template<> FEValues<3> &FETransportObjects::fe_values<1>() { return fe_values1_; }
-template<> FEValues<3> &FETransportObjects::fe_values<2>() { return fe_values2_; }
-template<> FEValues<3> &FETransportObjects::fe_values<3>() { return fe_values3_; }
 
 
 /********************************************************************************
@@ -904,8 +901,8 @@ double ConvectionTransport::calculate_side_flux(const DHCellSide &cell_side)
 {
     ASSERT_EQ(cell_side.dim(), dim).error("Element dimension mismatch!");
 
-    feo_.fe_values<dim>().reinit(cell_side.side());
+    feo_.fe_values(dim).reinit(cell_side.side());
     auto vel = velocity_field_ptr_->value(cell_side.centre(), cell_side.element());
-    double side_flux = arma::dot(vel, feo_.fe_values<dim>().normal_vector(0)) * feo_.fe_values<dim>().JxW(0);
+    double side_flux = arma::dot(vel, feo_.fe_values(dim).normal_vector(0)) * feo_.fe_values(dim).JxW(0);
     return side_flux;
 }

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -127,11 +127,11 @@ FETransportObjects::FETransportObjects()
     fe3_ = new FE_P_disc<3>(0);
 
 
-    fe_values1_ = new FESideValues<1,3>(q(0), *fe1_,
+    fe_values1_.initialize(q(0), *fe1_,
             update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
-    fe_values2_ = new FESideValues<2,3>(q(1), *fe2_,
+    fe_values2_.initialize(q(1), *fe2_,
             update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
-    fe_values3_ = new FESideValues<3,3>(q(2), *fe3_,
+    fe_values3_.initialize(q(2), *fe3_,
             update_values | update_gradients | update_side_JxW_values | update_normal_vectors | update_quadrature_points);
 }
 
@@ -142,9 +142,6 @@ FETransportObjects::~FETransportObjects()
     delete fe1_;
     delete fe2_;
     delete fe3_;
-    delete fe_values1_;
-    delete fe_values2_;
-    delete fe_values3_;
 }
 
 template<> FiniteElement<0> *FETransportObjects::fe<0>() { return fe0_; }
@@ -154,9 +151,9 @@ template<> FiniteElement<3> *FETransportObjects::fe<3>() { return fe3_; }
 
 Quadrature &FETransportObjects::q(unsigned int dim) { return q_[dim]; }
 
-template<> FESideValues<1,3> *FETransportObjects::fe_values<1>() { return fe_values1_; }
-template<> FESideValues<2,3> *FETransportObjects::fe_values<2>() { return fe_values2_; }
-template<> FESideValues<3,3> *FETransportObjects::fe_values<3>() { return fe_values3_; }
+template<> FESideValues<3> &FETransportObjects::fe_values<1>() { return fe_values1_; }
+template<> FESideValues<3> &FETransportObjects::fe_values<2>() { return fe_values2_; }
+template<> FESideValues<3> &FETransportObjects::fe_values<3>() { return fe_values3_; }
 
 
 /********************************************************************************
@@ -907,8 +904,8 @@ double ConvectionTransport::calculate_side_flux(const DHCellSide &cell_side)
 {
     ASSERT_EQ(cell_side.dim(), dim).error("Element dimension mismatch!");
 
-    feo_.fe_values<dim>()->reinit(cell_side.side());
+    feo_.fe_values<dim>().reinit(cell_side.side());
     auto vel = velocity_field_ptr_->value(cell_side.centre(), cell_side.element());
-    double side_flux = arma::dot(vel, feo_.fe_values<dim>()->normal_vector(0)) * feo_.fe_values<dim>()->JxW(0);
+    double side_flux = arma::dot(vel, feo_.fe_values<dim>().normal_vector(0)) * feo_.fe_values<dim>().JxW(0);
     return side_flux;
 }

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -151,9 +151,9 @@ template<> FiniteElement<3> *FETransportObjects::fe<3>() { return fe3_; }
 
 Quadrature &FETransportObjects::q(unsigned int dim) { return q_[dim]; }
 
-template<> FESideValues<3> &FETransportObjects::fe_values<1>() { return fe_values1_; }
-template<> FESideValues<3> &FETransportObjects::fe_values<2>() { return fe_values2_; }
-template<> FESideValues<3> &FETransportObjects::fe_values<3>() { return fe_values3_; }
+template<> FEValues<3> &FETransportObjects::fe_values<1>() { return fe_values1_; }
+template<> FEValues<3> &FETransportObjects::fe_values<2>() { return fe_values2_; }
+template<> FEValues<3> &FETransportObjects::fe_values<3>() { return fe_values3_; }
 
 
 /********************************************************************************

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -89,8 +89,11 @@ public:
 
 	inline Quadrature &q(unsigned int dim);
 
-	template<unsigned int dim>
-	inline FEValues<3> &fe_values();
+	inline FEValues<3> &fe_values(unsigned int dim)
+    { 
+        ASSERT_DBG( dim >= 1 && dim <= 3 );
+        return fe_values_[dim-1];
+    }
 
 private:
 
@@ -104,9 +107,7 @@ private:
 	QGauss::array q_;
 
     /// FESideValues objects for side flux calculating.
-	FEValues<3> fe_values1_;
-    FEValues<3> fe_values2_;
-    FEValues<3> fe_values3_;
+	FEValues<3> fe_values_[3];
 };
 
 

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -90,7 +90,7 @@ public:
 	inline Quadrature &q(unsigned int dim);
 
 	template<unsigned int dim>
-	inline FESideValues<3> &fe_values();
+	inline FEValues<3> &fe_values();
 
 private:
 
@@ -104,9 +104,9 @@ private:
 	QGauss::array q_;
 
     /// FESideValues objects for side flux calculating.
-	FESideValues<3> fe_values1_;
-    FESideValues<3> fe_values2_;
-    FESideValues<3> fe_values3_;
+	FEValues<3> fe_values1_;
+    FEValues<3> fe_values2_;
+    FEValues<3> fe_values3_;
 };
 
 

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -90,7 +90,7 @@ public:
 	inline Quadrature &q(unsigned int dim);
 
 	template<unsigned int dim>
-	inline FESideValues<dim,3> *fe_values();
+	inline FESideValues<3> &fe_values();
 
 private:
 
@@ -104,9 +104,9 @@ private:
 	QGauss::array q_;
 
     /// FESideValues objects for side flux calculating.
-	FESideValues<1,3> *fe_values1_;
-    FESideValues<2,3> *fe_values2_;
-    FESideValues<3,3> *fe_values3_;
+	FESideValues<3> fe_values1_;
+    FESideValues<3> fe_values2_;
+    FESideValues<3> fe_values3_;
 };
 
 

--- a/src/transport/transport_dg.hh
+++ b/src/transport/transport_dg.hh
@@ -57,7 +57,6 @@ class OutputTime;
 class DOFHandlerMultiDim;
 class AssemblyDGBase;
 template<unsigned int dim, class Model> class AssemblyDG;
-template<unsigned int dim, unsigned int spacedim> class FEValuesBase;
 template<unsigned int dim> class FiniteElement;
 template<unsigned int dim, unsigned int spacedim> class Mapping;
 class Quadrature;

--- a/unit_tests/fem/fe_system_test.cpp
+++ b/unit_tests/fem/fe_system_test.cpp
@@ -102,7 +102,7 @@ protected:
 TEST_F(FESystemTest, test_vector) {
   // Test vector-valued FESystem using P1 element on tetrahedron.
   FESystem<3> fe_sys(std::make_shared<FE_P<3> >(1), FEVectorContravariant);
-  FEValues<3,3> fe_values(q, fe_sys, update_values | update_gradients);
+  FEValues<3> fe_values(q, fe_sys, update_values | update_gradients);
   
   fe_values.reinit(ele);
   
@@ -143,7 +143,7 @@ TEST_F(FESystemTest, test_vector) {
 TEST_F(FESystemTest, test_tensor) {
   // Test vector-valued FESystem using P1 element on tetrahedron.
   FESystem<3> fe_tensor(std::make_shared<FE_P<3> >(1), FETensor, 9);
-  FEValues<3,3> fe_values(q, fe_tensor, update_values | update_gradients);
+  FEValues<3> fe_values(q, fe_tensor, update_values | update_gradients);
   
   fe_values.reinit(ele);
   
@@ -198,7 +198,7 @@ TEST_F(FESystemTest, test_mixed_system) {
   // functions from P1^3 and the RT0 functions are at the end.
   FESystem<3> fe_vec(std::make_shared<FE_P<3> >(1), FEVector, 3);
   FESystem<3> fe_sys({ std::make_shared<FE_P<3> >(0), std::make_shared<FESystem<3> >(fe_vec), std::make_shared<FE_RT0<3> >() });
-  FEValues<3,3> fe_values(q, fe_sys, update_values | update_gradients);
+  FEValues<3> fe_values(q, fe_sys, update_values | update_gradients);
   
   std::vector<std::vector<unsigned int> > fe_dof_indices = { fe_sys.fe_dofs(0), fe_sys.fe_dofs(1), fe_sys.fe_dofs(2) };
   std::vector<std::vector<unsigned int> > ref_indices = { {0}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {13, 14, 15, 16} };

--- a/unit_tests/fem/fe_values_test.cpp
+++ b/unit_tests/fem/fe_values_test.cpp
@@ -44,7 +44,7 @@ double integrate(ElementAccessor<3> &ele) {
     FE_P_disc<dim> fe(0);
     QGauss quad( dim, 2 );
     MappingP1<dim,3> map;
-    FEValues<dim,3> fe_values(quad, fe, update_JxW_values | update_quadrature_points);
+    FEValues<3> fe_values(quad, fe, update_JxW_values | update_quadrature_points);
     
     fe_values.reinit( ele );
     

--- a/unit_tests/fields/field_fe_test.cpp
+++ b/unit_tests/fields/field_fe_test.cpp
@@ -104,10 +104,15 @@ TEST_F(FieldFETest, scalar) {
     field.set_fe_data(dh, 0, v);
     field.set_time(0.0);
 
+    Armor::array pts(3, 1);
+    pts.reinit(3);
+    pts.append(Armor::vec<3>({ 1, 1, 5 }));
+    pts.append(Armor::vec<3>({ 4, 0, 5 }));
+    pts.append(Armor::vec<3>({ 2, 3, 5 }));
     vector<double> values(3);
 
     // test values at vertices of the triangle
-    field.value_list( { { 1, 1, 5 }, { 4, 0, 5 }, { 2, 3, 5 } }, mesh->element_accessor(0), values );
+    field.value_list( pts, mesh->element_accessor(0), values );
     EXPECT_DOUBLE_EQ( dof_values[0], values[0] );
     EXPECT_DOUBLE_EQ( dof_values[1], values[1] );
     EXPECT_DOUBLE_EQ( dof_values[2], values[2] );


### PR DESCRIPTION
Finished simplification of FEValues (#1136). Main change is the removal of template parameter "dim" and unification of FEValues, FESideValues, FEValuesSpaceBase and FEValuesBase. Further remarks:
- Methods reinit() in ElementValues and FEValues take ElementAccessor/Side as argument instead of DHCellAccessor/DHCellSide. This is because we do not need to work with DOFHandler and there is problem on boundary elements, where DOFHandler cannot be used so far.
- FEValues does not store pointer to FiniteElement<dim> (because the template parameter dim is not available). Instead it saves necessary data such as number of components, structure of dofs etc.