### PR TITLE
Template record in EquationBase with key 'time'.

### DIFF
--- a/src/coupling/equation.cc
+++ b/src/coupling/equation.cc
@@ -33,6 +33,13 @@
  * Implementation of EqBase
  */
 
+Input::Type::Record & EquationBase::record_template() {
+    return Input::Type::Record("EquationBase_AUX", "Auxiliary record with keys common for equations. Should not be used.")
+        .declare_key("time", TimeGovernor::get_input_type(), Input::Type::Default("{}"),
+                    "Time governor setting.")
+		    .close();
+}
+
 EquationBase::EquationBase()
 : equation_empty_(true),
   mesh_(NULL),

--- a/src/coupling/equation.hh
+++ b/src/coupling/equation.hh
@@ -59,6 +59,9 @@ class Mesh;
 class EquationBase {
 public:
 
+    /// Template Record with common keys for derived equations.
+    static Input::Type::Record & record_template();
+
     /**
      * Default constructor. Sets all virtual methods empty. Necessary to make tests fixtures for equations.
      * TODO:

--- a/src/coupling/hc_explicit_sequential.cc
+++ b/src/coupling/hc_explicit_sequential.cc
@@ -60,13 +60,12 @@ const it::Record & HC_ExplicitSequential::get_input_type() {
     return it::Record("Coupling_Sequential",
             "Record with data for a general sequential coupling.\n")
 		.derive_from( CouplingBase::get_input_type() )
+        .copy_keys(EquationBase::record_template())
 		.declare_key("description",it::String(),
 				"Short description of the solved problem.\n"
 				"Is displayed in the main log, and possibly in other text output files.")
 		.declare_key("mesh", Mesh::get_input_type(), it::Default::obligatory(),
 				"Computational mesh common to all equations.")
-		.declare_key("time", TimeGovernor::get_input_type(), it::Default::optional(),
-				"Simulation time frame and time step.")
 		.declare_key("flow_equation", DarcyFlowInterface::get_input_type(),
 		        it::Default::obligatory(),
 				"Flow equation, provides the velocity field as a result.")

--- a/src/coupling/hc_explicit_sequential.hh
+++ b/src/coupling/hc_explicit_sequential.hh
@@ -35,7 +35,7 @@ class FieldCommon;
 /**
  * TODO: should be derived from EquationBase in order to chain couplings
  */
-class CouplingBase {
+class CouplingBase : public EquationBase {
 public:
     static Input::Type::Abstract & get_input_type();
 

--- a/src/coupling/hm_iterative.cc
+++ b/src/coupling/hm_iterative.cc
@@ -33,13 +33,12 @@ const it::Record & HM_Iterative::get_input_type() {
     return it::Record("Coupling_Iterative",
             "Record with data for iterative coupling of flow and mechanics.\n")
         .derive_from( DarcyFlowInterface::get_input_type() )
+        .copy_keys(EquationBase::record_template())
 		.declare_key("flow_equation", RichardsLMH::get_input_type(),
 		        it::Default::obligatory(),
 				"Flow equation, provides the velocity field as a result.")
 		.declare_key("mechanics_equation", Elasticity::get_input_type(),
 				"Mechanics, provides the displacement field.")
-        .declare_key("time", TimeGovernor::get_input_type(), it::Default::obligatory(),
-                    "Time governor setting for the HM coupling.")
         .declare_key("input_fields", it::Array(
 		        HM_Iterative::EqData()
 		            .make_field_descriptor_type("Coupling_Iterative")),
@@ -124,6 +123,7 @@ HM_Iterative::HM_Iterative(Mesh &mesh, Input::Record in_record)
     using namespace Input;
 
     time_ = new TimeGovernor(in_record.val<Record>("time"));
+    ASSERT( time_->is_default() == false ).error("Missing key 'time' in Coupling_Iterative.");
     
     // setup flow equation
     Record flow_rec = in_record.val<Record>("flow_equation");

--- a/src/flow/darcy_flow_lmh.cc
+++ b/src/flow/darcy_flow_lmh.cc
@@ -120,6 +120,7 @@ const it::Record & DarcyLMH::get_input_type() {
     
     return it::Record("Flow_Darcy_LMH", "Lumped Mixed-Hybrid solver for saturated Darcy flow.")
 		.derive_from(DarcyFlowInterface::get_input_type())
+        .copy_keys(EquationBase::record_template())
         .declare_key("gravity", it::Array(it::Double(), 3,3), it::Default("[ 0, 0, -1]"),
                 "Vector of the gravity force. Dimensionless.")
 		.declare_key("input_fields", it::Array( type_field_descriptor() ), it::Default::obligatory(),
@@ -137,8 +138,6 @@ const it::Record & DarcyLMH::get_input_type() {
                 "Includes raw output and some experimental functionality.")
         .declare_key("balance", Balance::get_input_type(), it::Default("{}"),
                 "Settings for computing mass balance.")
-        .declare_key("time", TimeGovernor::get_input_type(), it::Default("{}"),
-                "Time governor settings for the unsteady Darcy flow model.")
 		.declare_key("mortar_method", get_mh_mortar_selection(), it::Default("\"None\""),
 				"Method for coupling Darcy flow between dimensions on incompatible meshes. [Experimental]" )
 		.close();

--- a/src/flow/darcy_flow_mh.cc
+++ b/src/flow/darcy_flow_mh.cc
@@ -150,6 +150,7 @@ const it::Record & DarcyMH::get_input_type() {
     
     return it::Record("Flow_Darcy_MH", "Mixed-Hybrid  solver for saturated Darcy flow.")
 		.derive_from(DarcyFlowInterface::get_input_type())
+        .copy_keys(EquationBase::record_template())
         .declare_key("gravity", it::Array(it::Double(), 3,3), it::Default("[ 0, 0, -1]"),
                 "Vector of the gravity force. Dimensionless.")
 		.declare_key("input_fields", it::Array( type_field_descriptor() ), it::Default::obligatory(),
@@ -167,8 +168,6 @@ const it::Record & DarcyMH::get_input_type() {
                 "Includes raw output and some experimental functionality.")
         .declare_key("balance", Balance::get_input_type(), it::Default("{}"),
                 "Settings for computing mass balance.")
-        .declare_key("time", TimeGovernor::get_input_type(), it::Default("{}"),
-                "Time governor settings for the unsteady Darcy flow model.")
 		.declare_key("n_schurs", it::Integer(0,2), it::Default("2"),
 				"Number of Schur complements to perform when solving MH system.")
 		.declare_key("mortar_method", get_mh_mortar_selection(), it::Default("\"None\""),

--- a/src/mechanics/elasticity.cc
+++ b/src/mechanics/elasticity.cc
@@ -45,8 +45,7 @@ const Record & Elasticity::get_input_type() {
 	return IT::Record(
                 std::string(equation_name),
                 "FEM for linear elasticity.")
-           .declare_key("time", TimeGovernor::get_input_type(), Default::optional(),
-                    "Time governor setting for the secondary equation.")
+           .copy_keys(EquationBase::record_template())
            .declare_key("balance", Balance::get_input_type(), Default("{}"),
                     "Settings for computing balance.")
            .declare_key("output_stream", OutputTime::get_input_type(), Default::obligatory(),
@@ -267,18 +266,15 @@ Elasticity::Elasticity(Mesh & init_mesh, const Input::Record in_rec, TimeGoverno
 
 	this->eq_data_ = &data_;
     
-    auto time_rec = in_rec.find<Input::Record>("time");
+    auto time_rec = in_rec.val<Input::Record>("time");
     if (tm == nullptr)
     {
-        if (time_rec)
-            time_ = new TimeGovernor(time_rec);
-        else
-            time_ = new TimeGovernor();
+        time_ = new TimeGovernor(time_rec);
     }
     else
     {
-        if (time_rec)
-            WarningOut() << "Time governor of Elasticity is initialized from parent class - input record will be ignored!";
+        TimeGovernor time_from_rec(time_rec);
+        ASSERT( time_from_rec.is_default() ).error("Duplicate key 'time', time in elasticity is already initialized from parent class!");
         time_ = tm;
     }
 

--- a/src/transport/heat_model.cc
+++ b/src/transport/heat_model.cc
@@ -229,8 +229,7 @@ IT::Record HeatTransferModel::get_input_type(const string &implementation, const
 				std::string(ModelEqData::name()) + "_" + implementation,
 				description + " for heat transfer.")
 			.derive_from(AdvectionProcessBase::get_input_type())
-			.declare_key("time", TimeGovernor::get_input_type(), Default::obligatory(),
-					"Time governor setting for the secondary equation.")
+			.copy_keys(EquationBase::record_template())
 			.declare_key("balance", Balance::get_input_type(), Default("{}"),
 					"Settings for computing balance.")
 			.declare_key("output_stream", OutputTime::get_input_type(), Default("{}"),
@@ -253,6 +252,7 @@ HeatTransferModel::HeatTransferModel(Mesh &mesh, const Input::Record in_rec) :
 		flux_changed(true)
 {
 	time_ = new TimeGovernor(in_rec.val<Input::Record>("time"));
+	ASSERT( time_->is_default() == false ).error("Missing key 'time' in Heat_AdvectionDiffusion_DG.");
 	substances_.initialize({""});
 
     output_stream_ = OutputTime::create_output_stream("heat", in_rec.val<Input::Record>("output_stream"), time().get_unit_string());

--- a/src/transport/transport_operator_splitting.cc
+++ b/src/transport/transport_operator_splitting.cc
@@ -73,8 +73,7 @@ const Record & TransportOperatorSplitting::get_input_type() {
             " via operator splitting.")
 		.derive_from(AdvectionProcessBase::get_input_type())
 		.add_attribute( FlowAttribute::subfields_address(), "\"/problem/solute_equation/substances/*/name\"")
-		.declare_key("time", TimeGovernor::get_input_type(), Default::obligatory(),
-				"Time governor settings for the transport equation.")
+    .copy_keys(EquationBase::record_template())
 		.declare_key("balance", Balance::get_input_type(), Default("{}"),
 				"Settings for computing mass balance.")
 		.declare_key("output_stream", OutputTime::get_input_type(), Default("{}"),
@@ -165,6 +164,7 @@ TransportOperatorSplitting::TransportOperatorSplitting(Mesh &init_mesh, const In
 	convection = trans.factory< ConcentrationTransportBase, Mesh &, const Input::Record >(init_mesh, trans);
 
 	time_ = new TimeGovernor(in_rec.val<Input::Record>("time"), TimeMark::none_type, false);
+  ASSERT( time_->is_default() == false ).error("Missing key 'time' in Coupling_OperatorSplitting.");
 	convection->set_time_governor(time());
 
 	// Initialize list of substances.


### PR DESCRIPTION
Equations which use time key now inherit their input record from EquationBase and thus use the same settings for time governor.
Now time key is obligatory with empty default value.

Question: How about HC_ExplicitSequential? It has key "time" but is not descendant of EquationBase. Should its input record also copy keys from EquationBase::record_template()?