### PR TITLE
Pe pass vel

### DIFF
--- a/src/coupling/hc_explicit_sequential.cc
+++ b/src/coupling/hc_explicit_sequential.cc
@@ -175,8 +175,9 @@ void HC_ExplicitSequential::advection_process_step(AdvectionData &pdata)
         // for simplicity we use only last velocity field
         if (pdata.velocity_changed) {
             //DBGMSG("velocity update\n");
-            pdata.process->data()["flow_flux"].copy_from(water->data()["flux"]);
-            pdata.process->set_velocity_changed();
+            auto& flux = pdata.process->data()["flow_flux"];
+            flux.copy_from(water->data()["flux"]);
+            flux.set_time_result_changed();
             pdata.velocity_changed = false;
         }
         if (pdata.process->time().tlevel() == 0) pdata.process->zero_time_step();

--- a/src/coupling/hc_explicit_sequential.cc
+++ b/src/coupling/hc_explicit_sequential.cc
@@ -175,12 +175,8 @@ void HC_ExplicitSequential::advection_process_step(AdvectionData &pdata)
         // for simplicity we use only last velocity field
         if (pdata.velocity_changed) {
             //DBGMSG("velocity update\n");
-//             std::dynamic_pointer_cast<DarcyMH>(water)->get_velocity_field()->local_to_ghost_data_scatter_begin();
-//             std::dynamic_pointer_cast<DarcyMH>(water)->get_velocity_field()->local_to_ghost_data_scatter_end();
-//             pdata.process->set_velocity_field( std::dynamic_pointer_cast<DarcyMH>(water)->get_velocity_field() );
-            water->get_velocity_field()->local_to_ghost_data_scatter_begin();
-            water->get_velocity_field()->local_to_ghost_data_scatter_end();
-            pdata.process->set_velocity_field( water->get_velocity_field() );
+            pdata.process->data()["flow_flux"].copy_from(water->data()["flux"]);
+            pdata.process->set_velocity_changed();
             pdata.velocity_changed = false;
         }
         if (pdata.process->time().tlevel() == 0) pdata.process->zero_time_step();

--- a/src/coupling/hm_iterative.cc
+++ b/src/coupling/hm_iterative.cc
@@ -320,12 +320,6 @@ void HM_Iterative::compute_iteration_error(double& abs_error, double& rel_error)
 
 
 
-double HM_Iterative::last_t()
-{
-    return flow_->last_t();
-}
-
-
 HM_Iterative::~HM_Iterative() {
 	flow_.reset();
     mechanics_.reset();

--- a/src/coupling/hm_iterative.hh
+++ b/src/coupling/hm_iterative.hh
@@ -156,7 +156,6 @@ public:
     void initialize() override;
     void zero_time_step() override;
     void update_solution() override;
-    double last_t() override;
     ~HM_Iterative();
 
 private:

--- a/src/flow/darcy_flow_interface.hh
+++ b/src/flow/darcy_flow_interface.hh
@@ -12,8 +12,6 @@
 #include "coupling/equation.hh"
 #include "fields/field_values.hh"
 
-template <int spacedim, class Value> class FieldFE;
-
 class DarcyFlowInterface : public EquationBase {
 public:
     /// Typedef for usage of Input::Factory in child classes.
@@ -35,9 +33,6 @@ public:
     DarcyFlowInterface(Mesh &mesh, const Input::Record in_rec)
     : EquationBase(mesh, in_rec)
     {}
-
-    /// Return last time of TimeGovernor.
-    virtual double last_t() =0;
     
     virtual ~DarcyFlowInterface()
     {}

--- a/src/flow/darcy_flow_interface.hh
+++ b/src/flow/darcy_flow_interface.hh
@@ -38,10 +38,6 @@ public:
 
     /// Return last time of TimeGovernor.
     virtual double last_t() =0;
-
-    // TODO: remove! Due to MH and LMH Darcy flow versions.
-    virtual std::shared_ptr< FieldFE<3, FieldValue<3>::VectorFixed> > get_velocity_field()
-    { return nullptr; }
     
     virtual ~DarcyFlowInterface()
     {}

--- a/src/flow/darcy_flow_lmh.cc
+++ b/src/flow/darcy_flow_lmh.cc
@@ -289,12 +289,12 @@ void DarcyLMH::initialize() {
 
     { // construct pressure, velocity and piezo head fields
 		uint rt_component = 0;
-        ele_flux_ptr = create_field_fe<3, FieldValue<3>::VectorFixed>(data_->dh_, rt_component);
+        auto ele_flux_ptr = create_field_fe<3, FieldValue<3>::VectorFixed>(data_->dh_, rt_component);
+        data_->full_solution = ele_flux_ptr->get_data_vec();
+        data_->flux.set_field(mesh_->region_db().get_region_set("ALL"), ele_flux_ptr);
+
 		auto ele_velocity_ptr = std::make_shared< FieldDivide<3, FieldValue<3>::VectorFixed> >(ele_flux_ptr, data_->cross_section);
 		data_->field_ele_velocity.set_field(mesh_->region_db().get_region_set("ALL"), ele_velocity_ptr);
-		data_->full_solution = ele_flux_ptr->get_data_vec();
-
-        data_->flux.set_field(mesh_->region_db().get_region_set("ALL"), ele_flux_ptr);
 
 		uint p_ele_component = 0;
         auto ele_pressure_ptr = create_field_fe<3, FieldValue<3>::Scalar>(data_->dh_, p_ele_component, &data_->full_solution);
@@ -487,8 +487,8 @@ void DarcyLMH::update_solution()
 
     solve_time_step();
     
-    ele_flux_ptr->local_to_ghost_data_scatter_begin();
-    ele_flux_ptr->local_to_ghost_data_scatter_end();
+    data_->full_solution.local_to_ghost_begin();
+    data_->full_solution.local_to_ghost_end();
 }
 
 void DarcyLMH::solve_time_step(bool output)

--- a/src/flow/darcy_flow_lmh.cc
+++ b/src/flow/darcy_flow_lmh.cc
@@ -294,6 +294,8 @@ void DarcyLMH::initialize() {
 		data_->field_ele_velocity.set_field(mesh_->region_db().get_region_set("ALL"), ele_velocity_ptr);
 		data_->full_solution = ele_flux_ptr->get_data_vec();
 
+        data_->flux.set_field(mesh_->region_db().get_region_set("ALL"), ele_flux_ptr);
+
 		uint p_ele_component = 0;
         auto ele_pressure_ptr = create_field_fe<3, FieldValue<3>::Scalar>(data_->dh_, p_ele_component, &data_->full_solution);
 		data_->field_ele_pressure.set_field(mesh_->region_db().get_region_set("ALL"), ele_pressure_ptr);
@@ -484,6 +486,9 @@ void DarcyLMH::update_solution()
     time_->view("DARCY"); //time governor information output
 
     solve_time_step();
+    
+    ele_flux_ptr->local_to_ghost_data_scatter_begin();
+    ele_flux_ptr->local_to_ghost_data_scatter_end();
 }
 
 void DarcyLMH::solve_time_step(bool output)
@@ -1298,11 +1303,6 @@ DarcyLMH::~DarcyLMH() {
     if(time_ != nullptr)
         delete time_;
     
-}
-
-
-std::shared_ptr< FieldFE<3, FieldValue<3>::VectorFixed> > DarcyLMH::get_velocity_field() {
-    return ele_flux_ptr;
 }
 
 

--- a/src/flow/darcy_flow_lmh.hh
+++ b/src/flow/darcy_flow_lmh.hh
@@ -185,8 +185,6 @@ public:
         return time_->last_t();
     }
 
-    std::shared_ptr< FieldFE<3, FieldValue<3>::VectorFixed> > get_velocity_field() override;
-
     void init_eq_data();
     void initialize() override;
     virtual void initialize_specific();

--- a/src/flow/darcy_flow_lmh.hh
+++ b/src/flow/darcy_flow_lmh.hh
@@ -303,10 +303,6 @@ protected:
 	unsigned int max_n_it_;
 	unsigned int nonlinear_iteration_; //< Actual number of completed nonlinear iterations, need to pass this information into assembly.
 
-    // Temporary objects holding pointers to appropriate FieldFE
-    // TODO remove after final fix of equations
-    std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> ele_flux_ptr;            ///< Field of flux in barycenter of every element.
-
 	std::shared_ptr<EqData> data_;
 
     friend class DarcyFlowMHOutput;

--- a/src/flow/darcy_flow_lmh.hh
+++ b/src/flow/darcy_flow_lmh.hh
@@ -181,10 +181,6 @@ public:
     static const Input::Type::Record & type_field_descriptor();
     static const Input::Type::Record & get_input_type();
 
-    double last_t() override {
-        return time_->last_t();
-    }
-
     void init_eq_data();
     void initialize() override;
     virtual void initialize_specific();

--- a/src/flow/darcy_flow_lmh.hh
+++ b/src/flow/darcy_flow_lmh.hh
@@ -44,7 +44,6 @@
 #include <armadillo>
 #include "fields/bc_field.hh"                   // for BCField
 #include "fields/field.hh"                      // for Field
-#include "fields/field_fe.hh"                      // for FieldFE
 #include "fields/field_set.hh"                  // for FieldSet
 #include "fields/field_values.hh"               // for FieldValue<>::Scalar
 #include "flow/darcy_flow_interface.hh"         // for DarcyFlowInterface

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -113,10 +113,6 @@ template<int spacedim, class Value> class FieldDivide;
  *
  * The time key is optional, when not specified the equation is forced to steady regime. Using Steady TimeGovernor which have no dt constraints.
  *
- *
- * TODO:
- * Make solution regular field (need FeSeystem and parallel DofHandler for edge pressures), then remove get_solution_vector from
- * Equation interface.
  */
 /**
  * Model for transition coefficients due to Martin, Jaffre, Roberts (see manual for full reference)
@@ -371,10 +367,6 @@ protected:
     Vec steady_rhs;
     Vec new_diagonal;
     Vec previous_solution;
-
-    // Temporary objects holding pointers to appropriate FieldFE
-    // TODO remove after final fix of equations
-    std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> ele_flux_ptr;            ///< Field of flux in barycenter of every element.
 
 	std::shared_ptr<EqData> data_;
 

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -188,6 +188,7 @@ public:
 	    Field<3, FieldValue<3>::Scalar> field_ele_pressure;
 	    Field<3, FieldValue<3>::Scalar> field_ele_piezo_head;
         Field<3, FieldValue<3>::VectorFixed > field_ele_velocity;
+        Field<3, FieldValue<3>::VectorFixed > flux;
         Field<3, FieldValue<3>::Scalar> field_edge_pressure;
 
         /**
@@ -238,8 +239,6 @@ public:
     double last_t() override {
         return time_->last_t();
     }
-
-    std::shared_ptr< FieldFE<3, FieldValue<3>::VectorFixed> > get_velocity_field() override;
 
     void init_eq_data();
     void initialize() override;

--- a/src/flow/darcy_flow_mh.hh
+++ b/src/flow/darcy_flow_mh.hh
@@ -232,10 +232,6 @@ public:
     static const Input::Type::Record & type_field_descriptor();
     static const Input::Type::Record & get_input_type();
 
-    double last_t() override {
-        return time_->last_t();
-    }
-
     void init_eq_data();
     void initialize() override;
     virtual void initialize_specific();

--- a/src/flow/darcy_flow_mh_output.cc
+++ b/src/flow/darcy_flow_mh_output.cc
@@ -216,14 +216,11 @@ void DarcyFlowMHOutput::prepare_specific_output(Input::Record in_rec)
 
     output_specific_fields.set_mesh(*mesh_);
 
-    diff_data.vel_diff_ptr = std::make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-    diff_data.vel_diff_ptr->set_fe_data(diff_data.dh_);
+    diff_data.vel_diff_ptr = create_field_fe<3, FieldValue<3>::Scalar>(diff_data.dh_);
     output_specific_fields.velocity_diff.set_field(mesh_->region_db().get_region_set("ALL"), diff_data.vel_diff_ptr, 0);
-    diff_data.pressure_diff_ptr = std::make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-    diff_data.pressure_diff_ptr->set_fe_data(diff_data.dh_);
+    diff_data.pressure_diff_ptr = create_field_fe<3, FieldValue<3>::Scalar>(diff_data.dh_);
     output_specific_fields.pressure_diff.set_field(mesh_->region_db().get_region_set("ALL"), diff_data.pressure_diff_ptr, 0);
-    diff_data.div_diff_ptr = std::make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-    diff_data.div_diff_ptr->set_fe_data(diff_data.dh_);
+    diff_data.div_diff_ptr = create_field_fe<3, FieldValue<3>::Scalar>(diff_data.dh_);
     output_specific_fields.div_diff.set_field(mesh_->region_db().get_region_set("ALL"), diff_data.div_diff_ptr, 0);
 
     output_specific_fields.set_time(darcy_flow->time().step(), LimitSide::right);

--- a/src/flow/richards_lmh.cc
+++ b/src/flow/richards_lmh.cc
@@ -148,14 +148,10 @@ void RichardsLMH::initialize_specific() {
     data_->mesh = mesh_;
     data_->set_mesh(*mesh_);
 
-    data_->water_content_ptr = std::make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-    data_->water_content_ptr->set_fe_data(data_->dh_cr_disc_, 0);
-    data_->water_content.set_mesh(*mesh_);
+    data_->water_content_ptr = create_field_fe< 3, FieldValue<3>::Scalar >(data_->dh_cr_disc_);
     data_->water_content.set_field(mesh_->region_db().get_region_set("ALL"), data_->water_content_ptr);
     
-    data_->conductivity_ptr = std::make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-    data_->conductivity_ptr->set_fe_data(data_->dh_p_, 0);
-    data_->conductivity_richards.set_mesh(*mesh_);
+    data_->conductivity_ptr = create_field_fe< 3, FieldValue<3>::Scalar >(data_->dh_p_);
     data_->conductivity_richards.set_field(mesh_->region_db().get_region_set("ALL"), data_->conductivity_ptr);
 
 

--- a/src/reaction/dual_porosity.cc
+++ b/src/reaction/dual_porosity.cc
@@ -213,9 +213,10 @@ void DualPorosity::initialize_fields()
   for (unsigned int sbi=0; sbi<substances_.size(); sbi++)
   {
     // create shared pointer to a FieldFE and push this Field to output_field on all regions
-    std::shared_ptr<FieldFE<3, FieldValue<3>::Scalar> > output_field_ptr = make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-    conc_immobile_out[sbi] = output_field_ptr->set_fe_data(this->dof_handler_);
+    auto output_field_ptr = create_field_fe< 3, FieldValue<3>::Scalar >(this->dof_handler_);
     data_.conc_immobile[sbi].set_field(mesh_->region_db().get_region_set("ALL"), output_field_ptr, 0);
+    
+    conc_immobile_out[sbi] = output_field_ptr->get_data_vec();
     double *out_array;
     VecGetArray(conc_immobile_out[sbi].petsc_vec(), &out_array);
     conc_immobile[sbi] = out_array;

--- a/src/reaction/dual_porosity.hh
+++ b/src/reaction/dual_porosity.hh
@@ -44,7 +44,6 @@ namespace Input {
 		class Record;
 	}
 }
-template <int spacedim, class Value> class FieldFE;
 
 
 /// Class representing dual porosity model in transport.

--- a/src/reaction/sorption_base.cc
+++ b/src/reaction/sorption_base.cc
@@ -348,9 +348,10 @@ void SorptionBase::initialize_fields()
   for (unsigned int sbi=0; sbi<substances_.size(); sbi++)
   {
       // create shared pointer to a FieldFE and push this Field to output_field on all regions
-      std::shared_ptr<FieldFE<3, FieldValue<3>::Scalar> > output_field_ptr = make_shared< FieldFE<3, FieldValue<3>::Scalar> >();
-      conc_solid_out[sbi] = output_field_ptr->set_fe_data(this->dof_handler_);
+      auto output_field_ptr = create_field_fe< 3, FieldValue<3>::Scalar >(this->dof_handler_);
       data_->conc_solid[sbi].set_field(mesh_->region_db().get_region_set("ALL"), output_field_ptr, 0);
+
+      conc_solid_out[sbi] = output_field_ptr->get_data_vec();
       double *out_array;
       VecGetArray(conc_solid_out[sbi].petsc_vec(), &out_array);
       conc_solid[sbi] = out_array;

--- a/src/reaction/sorption_base.hh
+++ b/src/reaction/sorption_base.hh
@@ -242,11 +242,6 @@ protected:
   //@{
   std::vector<VectorMPI> conc_solid_out; ///< sorbed concentration array output (gathered - sequential)
   //@}
-  
-  // Temporary objects holding pointers to appropriate FieldFE
-  // TODO remove after final fix of equations
-  /// Fields correspond with \p conc_solid_out.
-  std::vector< std::shared_ptr<FieldFE<3, FieldValue<3>::Scalar>> > output_field_ptr;
 
   /** Structure for data respectful to element, but indepedent of actual isotherm.
    * Reads mobile/immobile porosity, rock density and then computes concentration scaling parameters.

--- a/src/transport/advection_process_base.hh
+++ b/src/transport/advection_process_base.hh
@@ -34,7 +34,7 @@ public:
      *
      * TODO: We should pass whole velocity field object (description of base functions and dof numbering) and vector.
      */
-    virtual void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) = 0;
+    virtual void set_velocity_changed() = 0;
 
     /// Common specification of the input record for secondary equations.
     static Input::Type::Abstract & get_input_type() {

--- a/src/transport/advection_process_base.hh
+++ b/src/transport/advection_process_base.hh
@@ -10,12 +10,8 @@
 
 #include "coupling/equation.hh"
 #include "input/input_type_forward.hh"
-#include "fields/field_fe.hh"
 
-class Balance;
 class Mesh;
-class SubstanceList;
-
 
 /**
  * Abstract interface class for secondary equations in HC_ExplicitCoupling.
@@ -26,15 +22,6 @@ public:
     AdvectionProcessBase(Mesh &mesh, const Input::Record in_rec)
     : EquationBase(mesh, in_rec)
     {};
-
-    /**
-     * This method takes sequential PETSc vector of side velocities and update
-     * transport matrix. The ordering is same as ordering of sides in the mesh.
-     * We just keep the pointer, but do not destroy the object.
-     *
-     * TODO: We should pass whole velocity field object (description of base functions and dof numbering) and vector.
-     */
-    virtual void set_velocity_changed() = 0;
 
     /// Common specification of the input record for secondary equations.
     static Input::Type::Abstract & get_input_type() {

--- a/src/transport/assembly_dg.hh
+++ b/src/transport/assembly_dg.hh
@@ -503,7 +503,7 @@ public:
                                 const Armor::array &point_list)
         {
             velocity.resize(point_list.size());
-            model_->velocity_field_ptr()->value_list(point_list, cell, velocity);
+            model_->data().flow_flux->value_list(point_list, cell, velocity);
         }
 
         shared_ptr<FiniteElement<dim>> fe_;                    ///< Finite element for the solution of the advection-diffusion equation.
@@ -978,7 +978,7 @@ private:
                             const Armor::array &point_list)
     {
         velocity.resize(point_list.size());
-        model_->velocity_field_ptr()->value_list(point_list, cell, velocity);
+        model_->data().flow_flux.value_list(point_list, cell, velocity);
     }
 
     shared_ptr<FiniteElement<dim>> fe_;         ///< Finite element for the solution of the advection-diffusion equation.
@@ -1150,7 +1150,7 @@ public:
                                 const Armor::array &point_list)
         {
             velocity.resize(point_list.size());
-            model_->velocity_field_ptr()->value_list(point_list, cell, velocity);
+            model_->data().flow_flux.value_list(point_list, cell, velocity);
         }
 
         shared_ptr<FiniteElement<dim>> fe_;         ///< Finite element for the solution of the advection-diffusion equation.
@@ -1384,7 +1384,7 @@ public:
                                 const Armor::array &point_list)
         {
             velocity.resize(point_list.size());
-            model_->velocity_field_ptr()->value_list(point_list, cell, velocity);
+            model_->data().flow_flux.value_list(point_list, cell, velocity);
         }
 
         shared_ptr<FiniteElement<dim>> fe_;         ///< Finite element for the solution of the advection-diffusion equation.
@@ -1499,7 +1499,7 @@ public:
                                 const Armor::array &point_list)
         {
             velocity.resize(point_list.size());
-            model_->velocity_field_ptr()->value_list(point_list, cell, velocity);
+            model_->data().flow_flux.value_list(point_list, cell, velocity);
         }
 
         shared_ptr<FiniteElement<dim>> fe_;         ///< Finite element for the solution of the advection-diffusion equation.

--- a/src/transport/concentration_model.cc
+++ b/src/transport/concentration_model.cc
@@ -160,8 +160,7 @@ IT::Selection ConcentrationTransportModel::ModelEqData::get_output_selection()
 
 
 ConcentrationTransportModel::ConcentrationTransportModel(Mesh &mesh, const Input::Record &in_rec) :
-		ConcentrationTransportBase(mesh, in_rec),
-		flux_changed(true)
+		ConcentrationTransportBase(mesh, in_rec)
 {}
 
 

--- a/src/transport/concentration_model.hh
+++ b/src/transport/concentration_model.hh
@@ -150,20 +150,6 @@ public:
 
 	~ConcentrationTransportModel() override;
 
-
-	/**
-	 * @brief Updates the velocity field which determines some coefficients of the transport equation.
-	 *
-         * @param dh mixed hybrid dof handler
-         *
-	 * (So far it does not work since the flow module returns a vector of zeros.)
-	 * @param velocity_vector Input array of velocity values.
-	 */
-	inline void set_velocity_changed() override
-	{
-		flux_changed = true;
-	}
-
     /// Returns number of transported substances.
     inline unsigned int n_substances() override
     { return substances_.size(); }
@@ -221,9 +207,6 @@ protected:
 			double porosity,
 			double cross_cut,
 			arma::mat33 &K);
-
-	/// Indicator of change in advection vector field.
-	bool flux_changed;
 
     /// Transported substances.
     SubstanceList substances_;

--- a/src/transport/concentration_model.hh
+++ b/src/transport/concentration_model.hh
@@ -159,9 +159,8 @@ public:
 	 * (So far it does not work since the flow module returns a vector of zeros.)
 	 * @param velocity_vector Input array of velocity values.
 	 */
-	inline void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) override
+	inline void set_velocity_changed() override
 	{
-		velocity_field_ptr_ = flux_field;
 		flux_changed = true;
 	}
 
@@ -190,16 +189,11 @@ public:
 	std::shared_ptr<OutputTime> output_stream() override
 	{ return output_stream_; }
 
-    std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> velocity_field_ptr() const {
-        return this->velocity_field_ptr_;
-    }
-
-
-
-protected:
 
 	/// Derived class should implement getter for ModelEqData instance.
 	virtual ModelEqData &data() = 0;
+
+protected:
 
 	/**
 	 * Create input type that can be passed to the derived class.
@@ -241,11 +235,6 @@ protected:
 	double solvent_density_;
 
 	std::shared_ptr<OutputTime> output_stream_;
-
-	/// Pointer to velocity field given from Flow equation.
-	std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> velocity_field_ptr_;
-
-
 };
 
 

--- a/src/transport/heat_model.cc
+++ b/src/transport/heat_model.cc
@@ -252,8 +252,7 @@ IT::Selection HeatTransferModel::ModelEqData::get_output_selection()
 
 
 HeatTransferModel::HeatTransferModel(Mesh &mesh, const Input::Record in_rec) :
-		AdvectionProcessBase(mesh, in_rec),
-		flux_changed(true)
+		AdvectionProcessBase(mesh, in_rec)
 {
 	time_ = new TimeGovernor(in_rec.val<Input::Record>("time"));
 	ASSERT( time_->is_default() == false ).error("Missing key 'time' in Heat_AdvectionDiffusion_DG.");

--- a/src/transport/heat_model.cc
+++ b/src/transport/heat_model.cc
@@ -113,6 +113,10 @@ HeatTransferModel::ModelEqData::ModelEqData()
             .input_default("1.0")
             .flags_add(input_copy & in_main_matrix & in_time_term);
 
+    *this += flow_flux.name("flow_flux")
+               .flags( FieldFlag::input_copy )
+               .flags_add(in_time_term & in_main_matrix & in_rhs);
+
     *this+=fluid_density
             .name("fluid_density")
             .description("Density of fluid.")

--- a/src/transport/heat_model.hh
+++ b/src/transport/heat_model.hh
@@ -222,18 +222,6 @@ public:
 
 	~HeatTransferModel() override;
 
-	/**
-	 * @brief Updates the velocity field which determines some coefficients of the transport equation.
-	 *
-         * @param dh mixed hybrid dof handler
-         *
-	 * (So far it does not work since the flow module returns a vector of zeros.)
-	 */
-	inline void set_velocity_changed() override
-	{
-		flux_changed = true;
-	}
-
     /// Returns number of transported substances.
     inline unsigned int n_substances()
     { return 1; }
@@ -265,9 +253,6 @@ protected:
 	{ return output_stream_; }
 
 	virtual void calculate_cumulative_balance() = 0;
-
-	/// Indicator of change in advection vector field.
-	bool flux_changed;
 
     /// Transported substances.
     SubstanceList substances_;

--- a/src/transport/heat_model.hh
+++ b/src/transport/heat_model.hh
@@ -61,7 +61,7 @@ template <int spacedim> class ElementAccessor;
 //      *
 //      * TODO: We should pass whole velocity field object (description of base functions and dof numbering) and vector.
 //      */
-//     virtual void set_velocity_field(const MH_DofHandler &dh) = 0;
+//     virtual void set_velocity_changed() = 0;
 
 //     /// Common specification of the input record for secondary equations.
 //     static Input::Type::Abstract & get_input_type() {
@@ -86,7 +86,7 @@ public:
     inline virtual ~HeatNothing()
     {}
 
-    inline void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) override {};
+    inline void set_velocity_changed() override {};
 
     inline virtual void output_data() override {};
 
@@ -120,6 +120,8 @@ public:
 		Field<3, FieldValue<3>::Scalar> porosity;
 		/// Water content passed from Darcy flow model
 		Field<3, FieldValue<3>::Scalar> water_content;
+		/// Flow flux, can be result of water flow model.
+    	Field<3, FieldValue<3>::VectorFixed> flow_flux;
 		/// Density of fluid.
 		Field<3, FieldValue<3>::Scalar> fluid_density;
 		/// Heat capacity of fluid.
@@ -227,9 +229,8 @@ public:
          *
 	 * (So far it does not work since the flow module returns a vector of zeros.)
 	 */
-	inline void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) override
+	inline void set_velocity_changed() override
 	{
-		velocity_field_ptr_ = flux_field;
 		flux_changed = true;
 	}
 
@@ -244,16 +245,12 @@ public:
     const vector<unsigned int> &get_subst_idx()
 	{ return subst_idx; }
 
-    std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> velocity_field_ptr() const {
-        return this->velocity_field_ptr_;
-    }
-
-
-protected:
 
 	/// Derived class should implement getter for ModelEqData instance.
 	virtual ModelEqData &data() = 0;
 
+protected:
+	
 	/**
 	 * Create input type that can be passed to the derived class.
 	 * @param implementation String characterizing the numerical method, e.g. DG, FEM, FVM.
@@ -279,11 +276,6 @@ protected:
 	vector<unsigned int> subst_idx;
 
 	std::shared_ptr<OutputTime> output_stream_;
-
-	/// Pointer to velocity field given from Flow equation.
-	std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> velocity_field_ptr_;
-
-
 };
 
 

--- a/src/transport/transport.cc
+++ b/src/transport/transport.cc
@@ -900,7 +900,7 @@ double ConvectionTransport::calculate_side_flux(const DHCellSide &cell_side)
     ASSERT_EQ(cell_side.dim(), dim).error("Element dimension mismatch!");
 
     feo_.fe_values(dim).reinit(cell_side.side());
-    auto vel = velocity_field_ptr_->value(cell_side.centre(), cell_side.element());
+    auto vel = data_.flow_flux.value(cell_side.centre(), cell_side.element());
     double side_flux = arma::dot(vel, feo_.fe_values(dim).normal_vector(0)) * feo_.fe_values(dim).JxW(0);
     return side_flux;
 }

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -215,8 +215,8 @@ public:
      */
     virtual void output_data() override;
 
-    inline void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) override
-    { velocity_field_ptr_ = flux_field; changed_ = true; }
+    inline void set_velocity_changed() override
+    { changed_ = true; }
 
     void set_output_stream(std::shared_ptr<OutputTime> stream) override
     { output_stream_ = stream; }
@@ -378,9 +378,6 @@ private:
 
 	/// List of indices used to call balance methods for a set of quantities.
 	vector<unsigned int> subst_idx;
-
-	/// Pointer to velocity field given from Flow equation.
-	std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> velocity_field_ptr_;
 
 	/// Indicator of change in velocity field.
 	bool changed_;

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -27,6 +27,7 @@
 #include <memory>                                     // for shared_ptr
 #include <vector>                                     // for vector
 #include <petscmat.h>
+#include "fem/fe_values.hh"                           // for FEValues
 #include "fields/field.hh"                            // for Field
 #include "fields/bc_multi_field.hh"
 #include "fields/field_values.hh"
@@ -214,9 +215,6 @@ public:
      */
     virtual void output_data() override;
 
-    inline void set_velocity_changed() override
-    { changed_ = true; }
-
     void set_output_stream(std::shared_ptr<OutputTime> stream) override
     { output_stream_ = stream; }
 
@@ -370,9 +368,6 @@ private:
 
 	/// List of indices used to call balance methods for a set of quantities.
 	vector<unsigned int> subst_idx;
-
-	/// Indicator of change in velocity field.
-	bool changed_;
 
 	/// Finite element objects
 	FETransportObjects feo_;

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -54,7 +54,6 @@ namespace Input {
 		class Selection;
 	}
 }
-template <int spacedim, class Value> class FieldFE;
 
 
 //=============================================================================
@@ -348,13 +347,6 @@ private:
     Vec *bcvcorr; // boundary condition correction vector
     Vec *vcumulative_corr;
     double **cumulative_corr;
-
-    std::vector<VectorMPI> out_conc;
-
-    // Temporary objects holding pointers to appropriate FieldFE
-    // TODO remove after final fix of equations
-    /// Fields correspond with \p out_conc.
-    std::vector< std::shared_ptr<FieldFE<3, FieldValue<3>::Scalar>> > output_field_ptr;
 
 	/// Record with input specification.
 	const Input::Record input_rec;

--- a/src/transport/transport_dg.cc
+++ b/src/transport/transport_dg.cc
@@ -284,9 +284,9 @@ void TransportDG<Model>::initialize()
     for (unsigned int sbi=0; sbi<Model::n_substances(); sbi++)
     {
         // create shared pointer to a FieldFE, pass FE data and push this FieldFE to output_field on all regions
-        std::shared_ptr<FieldFE<3, FieldValue<3>::Scalar> > output_field_ptr(new FieldFE<3, FieldValue<3>::Scalar>);
-        output_vec[sbi] = output_field_ptr->set_fe_data(data_->dh_);
+        auto output_field_ptr = create_field_fe< 3, FieldValue<3>::Scalar >(data_->dh_);
         data_->output_field[sbi].set_field(Model::mesh_->region_db().get_region_set("ALL"), output_field_ptr, 0);
+        output_vec[sbi] = output_field_ptr->get_data_vec();
     }
 
     // set time marks for writing the output

--- a/src/transport/transport_dg.cc
+++ b/src/transport/transport_dg.cc
@@ -505,7 +505,7 @@ void TransportDG<Model>::update_solution()
     // assemble stiffness matrix
     if (stiffness_matrix[0] == NULL
             || data_->subset(FieldFlag::in_main_matrix).changed()
-            || Model::flux_changed)
+            || data_->flow_flux.changed())
     {
         // new fluxes can change the location of Neumann boundary,
         // thus stiffness matrix must be reassembled
@@ -531,7 +531,7 @@ void TransportDG<Model>::update_solution()
     // assemble right hand side (due to sources and boundary conditions)
     if (rhs[0] == NULL
             || data_->subset(FieldFlag::in_rhs).changed()
-            || Model::flux_changed)
+            || data_->flow_flux.changed())
     {
         for (unsigned int i=0; i<Model::n_substances(); i++)
         {
@@ -552,8 +552,6 @@ void TransportDG<Model>::update_solution()
             VecCopy(*( data_->ls[i]->get_rhs() ), rhs[i]);
         }
     }
-    
-    Model::flux_changed = false;
 
 
     /* Apply backward Euler time integration.

--- a/src/transport/transport_dg.hh
+++ b/src/transport/transport_dg.hh
@@ -309,13 +309,11 @@ public:
     }
 
 
-
+	inline typename Model::ModelEqData &data() { return *data_; }
 
 private:
     /// Registrar of class to factory
     static const int registrar;
-
-	inline typename Model::ModelEqData &data() { return *data_; }
 
 	void preallocate();
 

--- a/src/transport/transport_operator_splitting.cc
+++ b/src/transport/transport_operator_splitting.cc
@@ -119,6 +119,10 @@ TransportEqData::TransportEqData()
     *this += cross_section.name("cross_section")
                .flags( FieldFlag::input_copy )
                .flags_add(in_time_term & in_main_matrix & in_rhs);
+    
+    *this += flow_flux.name("flow_flux")
+               .flags( FieldFlag::input_copy )
+               .flags_add(in_time_term & in_main_matrix & in_rhs);
 
     *this += sources_density.name("sources_density")
             .description("Density of concentration sources.")
@@ -361,9 +365,9 @@ void TransportOperatorSplitting::update_solution() {
 
 
 
-void TransportOperatorSplitting::set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field)
+void TransportOperatorSplitting::set_velocity_changed()
 {
-	convection->set_velocity_field( flux_field );
+	convection->set_velocity_changed();
 }
 
 

--- a/src/transport/transport_operator_splitting.cc
+++ b/src/transport/transport_operator_splitting.cc
@@ -360,16 +360,3 @@ void TransportOperatorSplitting::update_solution() {
 
     LogOut().fmt("CONVECTION: steps: {}\n", steps);
 }
-
-
-
-
-
-void TransportOperatorSplitting::set_velocity_changed()
-{
-	convection->set_velocity_changed();
-}
-
-
-
-

--- a/src/transport/transport_operator_splitting.hh
+++ b/src/transport/transport_operator_splitting.hh
@@ -125,7 +125,7 @@ public:
 	virtual LongIdx *get_row_4_el() = 0;
 
 	/// Pass velocity from flow to transport.
-    virtual void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) = 0;
+    virtual void set_velocity_changed() = 0;
 
     /// Returns number of trnasported substances.
     virtual unsigned int n_substances() = 0;
@@ -157,6 +157,9 @@ public:
 
 	/// Pointer to DarcyFlow field cross_section
 	Field<3, FieldValue<3>::Scalar > cross_section;
+
+    /// Flow flux, can be result of water flow model.
+    Field<3, FieldValue<3>::VectorFixed > flow_flux;
 
 	/// Concentration sources - density of substance source, only positive part is used.
 	MultiField<3, FieldValue<3>::Scalar> sources_density;
@@ -190,7 +193,7 @@ public:
         if(time_) delete time_;
     }
 
-    inline void set_velocity_field(FMT_UNUSED std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) override {};
+    inline void set_velocity_changed() override {};
 
     inline virtual void output_data() override {};
 
@@ -228,7 +231,7 @@ public:
     /// Destructor.
     virtual ~TransportOperatorSplitting();
 
-    virtual void set_velocity_field(std::shared_ptr<FieldFE<3, FieldValue<3>::VectorFixed>> flux_field) override;
+    virtual void set_velocity_changed() override;
 
     void initialize() override;
     void zero_time_step() override;

--- a/src/transport/transport_operator_splitting.hh
+++ b/src/transport/transport_operator_splitting.hh
@@ -124,9 +124,6 @@ public:
 	/// Return global array of order of elements within parallel vector.
 	virtual LongIdx *get_row_4_el() = 0;
 
-	/// Pass velocity from flow to transport.
-    virtual void set_velocity_changed() = 0;
-
     /// Returns number of trnasported substances.
     virtual unsigned int n_substances() = 0;
 
@@ -193,8 +190,6 @@ public:
         if(time_) delete time_;
     }
 
-    inline void set_velocity_changed() override {};
-
     inline virtual void output_data() override {};
 
 
@@ -230,8 +225,6 @@ public:
     TransportOperatorSplitting(Mesh &init_mesh, const Input::Record in_rec);
     /// Destructor.
     virtual ~TransportOperatorSplitting();
-
-    virtual void set_velocity_changed() override;
 
     void initialize() override;
     void zero_time_step() override;


### PR DESCRIPTION
- pass flux from Darcy flow by data()
- clean up in DarcyFlowInterface
- simplify creation of FieldFE where applicable

question:
In transport, we have an auxiliary flag which is set when the flux is changed. I was thinking about using the property of the field `flow_flux->changed()` but that did not work for me (did some tests on 27/05).
Is this the way or not?